### PR TITLE
fix: add client-side required flag validation for all create and togg…

### DIFF
--- a/internal/cliapp/helpers.go
+++ b/internal/cliapp/helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -98,6 +99,25 @@ func MergeDataWithFlags(dataJSON string, cmd *cobra.Command, fieldMap map[string
 		result[apiField] = val
 	}
 	return result, nil
+}
+
+// RequireFlags returns a ValidationError if any of the named flags were not
+// explicitly set by the user. Call this inside RunE before making API calls.
+func RequireFlags(cmd *cobra.Command, flags ...string) error {
+	var missing []string
+	for _, name := range flags {
+		f := cmd.Flags().Lookup(name)
+		if f == nil || !f.Changed {
+			missing = append(missing, "--"+name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	if len(missing) == 1 {
+		return &ValidationError{Message: "missing required flag: " + missing[0]}
+	}
+	return &ValidationError{Message: "missing required flags: " + strings.Join(missing, ", ")}
 }
 
 // AddEnabledFlag adds --enabled flag accepting "yes" or "no".

--- a/internal/cliapp/helpers_test.go
+++ b/internal/cliapp/helpers_test.go
@@ -1,6 +1,7 @@
 package cliapp
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -190,6 +191,76 @@ func TestParseJSON_Invalid(t *testing.T) {
 	_, err := ParseJSON("bad")
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestRequireFlags_AllChanged(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("interface", "", "")
+	_ = cmd.Flags().Set("name", "foo")
+	_ = cmd.Flags().Set("interface", "eth0")
+	if err := RequireFlags(cmd, "name", "interface"); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestRequireFlags_OneMissing(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("name", "", "")
+	err := RequireFlags(cmd, "name")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var valErr *ValidationError
+	if !errors.As(err, &valErr) {
+		t.Fatalf("expected ValidationError, got %T", err)
+	}
+	if valErr.Message != "missing required flag: --name" {
+		t.Fatalf("unexpected message: %q", valErr.Message)
+	}
+}
+
+func TestRequireFlags_MultipleMissing(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("interface", "", "")
+	err := RequireFlags(cmd, "name", "interface")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var valErr *ValidationError
+	if !errors.As(err, &valErr) {
+		t.Fatalf("expected ValidationError, got %T", err)
+	}
+	if valErr.Message != "missing required flags: --name, --interface" {
+		t.Fatalf("unexpected message: %q", valErr.Message)
+	}
+}
+
+func TestRequireFlags_EmptyList(t *testing.T) {
+	cmd := &cobra.Command{}
+	if err := RequireFlags(cmd); err != nil {
+		t.Fatalf("expected nil for empty flag list, got %v", err)
+	}
+}
+
+func TestRequireFlags_PartiallySet(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("interface", "", "")
+	_ = cmd.Flags().Set("name", "foo")
+	// interface not set
+	err := RequireFlags(cmd, "name", "interface")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var valErr *ValidationError
+	if !errors.As(err, &valErr) {
+		t.Fatalf("expected ValidationError, got %T", err)
+	}
+	if valErr.Message != "missing required flag: --interface" {
+		t.Fatalf("unexpected message: %q", valErr.Message)
 	}
 }
 

--- a/internal/cmd/advanced/command.go
+++ b/internal/cmd/advanced/command.go
@@ -2,6 +2,7 @@ package advanced
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/ikuaidev/ikuai-cli/internal/cliapp"
 	"github.com/spf13/cobra"
@@ -124,18 +125,21 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		Short: "Advanced services",
 	}
 
-	advancedCmd.AddCommand(userGroup(app, "http", "HTTP server user management", "advanced-service/http-users", "", "", addHTTPFlags, httpFieldMap))
-	advancedCmd.AddCommand(serviceGroup(app, "ftp", "FTP server management", "advanced-service/ftp-config", "advanced-service/ftp-users", addFTPFlags, ftpFieldMap, addFTPConfigFlags, ftpConfigFieldMap))
-	advancedCmd.AddCommand(serviceGroup(app, "samba", "Samba share management", "advanced-service/samba-config", "advanced-service/samba-users", addSambaFlags, sambaFieldMap, addSambaConfigFlags, sambaConfigFieldMap))
+	advancedCmd.AddCommand(userGroup(app, "http", "HTTP server user management", "advanced-service/http-users", "", "", addHTTPFlags, httpFieldMap,
+		[]string{"name", "port", "ssl", "autoindex", "download", "home-dir"}))
+	advancedCmd.AddCommand(serviceGroup(app, "ftp", "FTP server management", "advanced-service/ftp-config", "advanced-service/ftp-users", addFTPFlags, ftpFieldMap, addFTPConfigFlags, ftpConfigFieldMap,
+		[]string{"username", "password", "permission", "home-dir"}))
+	advancedCmd.AddCommand(serviceGroup(app, "samba", "Samba share management", "advanced-service/samba-config", "advanced-service/samba-users", addSambaFlags, sambaFieldMap, addSambaConfigFlags, sambaConfigFieldMap,
+		[]string{"name", "username", "password", "permission", "guest"}))
 	advancedCmd.AddCommand(snmpdGroup(app))
 	return advancedCmd
 }
 
-func userGroup(app *cliapp.Runtime, use, short, userAPIPath, configGetPath, configSetPath string, addFlags func(*cobra.Command), fieldMap map[string]string) *cobra.Command {
-	return userGroupWithConfig(app, use, short, userAPIPath, configGetPath, configSetPath, addFlags, fieldMap, nil, nil)
+func userGroup(app *cliapp.Runtime, use, short, userAPIPath, configGetPath, configSetPath string, addFlags func(*cobra.Command), fieldMap map[string]string, requiredCreateFlags []string) *cobra.Command {
+	return userGroupWithConfig(app, use, short, userAPIPath, configGetPath, configSetPath, addFlags, fieldMap, nil, nil, requiredCreateFlags)
 }
 
-func userGroupWithConfig(app *cliapp.Runtime, use, short, userAPIPath, configGetPath, configSetPath string, addFlags func(*cobra.Command), fieldMap map[string]string, cfgAddFlags func(*cobra.Command), cfgFieldMap map[string]string) *cobra.Command {
+func userGroupWithConfig(app *cliapp.Runtime, use, short, userAPIPath, configGetPath, configSetPath string, addFlags func(*cobra.Command), fieldMap map[string]string, cfgAddFlags func(*cobra.Command), cfgFieldMap map[string]string, requiredCreateFlags []string) *cobra.Command {
 	group := &cobra.Command{Use: use, Short: short}
 
 	if configGetPath != "" && configSetPath != "" {
@@ -181,12 +185,22 @@ func userGroupWithConfig(app *cliapp.Runtime, use, short, userAPIPath, configGet
 	}
 	cliapp.AddListFlags(listCmd)
 
+	createCmd := dataCmd(app, "create", "Create a "+use+" user", addFlags, fieldMap, func(body interface{}, id string) (json.RawMessage, error) {
+		return app.APIClient.Post(cliapp.APIBase+"/"+userAPIPath, body)
+	})
+	if len(requiredCreateFlags) > 0 {
+		origRunE := createCmd.RunE
+		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := cliapp.RequireFlags(cmd, requiredCreateFlags...); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
 	group.AddCommand(
 		listCmd,
 		getByIDCmd(app, "get ID", "Get a "+use+" user", "/"+userAPIPath+"/"),
-		dataCmd(app, "create", "Create a "+use+" user", addFlags, fieldMap, func(body interface{}, id string) (json.RawMessage, error) {
-			return app.APIClient.Post(cliapp.APIBase+"/"+userAPIPath, body)
-		}),
+		createCmd,
 		dataCmdWithID(app, "update ID", "Update a "+use+" user", addFlags, fieldMap, func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Put(cliapp.APIBase+"/"+userAPIPath+"/"+id, body)
 		}),
@@ -199,8 +213,8 @@ func userGroupWithConfig(app *cliapp.Runtime, use, short, userAPIPath, configGet
 	return group
 }
 
-func serviceGroup(app *cliapp.Runtime, use, short, configAPIPath, userAPIPath string, addFlags func(*cobra.Command), fieldMap map[string]string, configAddFlags func(*cobra.Command), configFieldMap map[string]string) *cobra.Command {
-	return userGroupWithConfig(app, use, short, userAPIPath, configAPIPath, configAPIPath, addFlags, fieldMap, configAddFlags, configFieldMap)
+func serviceGroup(app *cliapp.Runtime, use, short, configAPIPath, userAPIPath string, addFlags func(*cobra.Command), fieldMap map[string]string, configAddFlags func(*cobra.Command), configFieldMap map[string]string, requiredCreateFlags []string) *cobra.Command {
+	return userGroupWithConfig(app, use, short, userAPIPath, configAPIPath, configAPIPath, addFlags, fieldMap, configAddFlags, configFieldMap, requiredCreateFlags)
 }
 
 func snmpdGroup(app *cliapp.Runtime) *cobra.Command {
@@ -297,6 +311,11 @@ func dataCmdImpl(app *cliapp.Runtime, use, short string, withID bool, addFlags f
 	c.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := app.RequireAuth(); err != nil {
 			return err
+		}
+		if strings.HasPrefix(use, "toggle") {
+			if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
+				return err
+			}
 		}
 		data, _ := cmd.Flags().GetString("data")
 		body, err := cliapp.MergeDataWithFlags(data, cmd, fieldMap)

--- a/internal/cmd/network/behavior_test.go
+++ b/internal/cmd/network/behavior_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/ikuaidev/ikuai-cli/internal/api"
@@ -60,6 +61,42 @@ func TestNatListBuildsExpectedQueryParams(t *testing.T) {
 	want := `{"items":[]}` + "\n"
 	if got != want {
 		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestDHCPCreateMissingRequiredFlags(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "tok"}
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"dhcp", "create", "--name", "test"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing required flags")
+	}
+	if !strings.Contains(err.Error(), "missing required flags") {
+		t.Fatalf("error = %q, want it to contain 'missing required flags'", err.Error())
+	}
+}
+
+func TestDHCPToggleMissingEnabled(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "tok"}
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"dhcp", "toggle", "1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing --enabled")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --enabled") {
+		t.Fatalf("error = %q, want 'missing required flag: --enabled'", err.Error())
 	}
 }
 

--- a/internal/cmd/network/command.go
+++ b/internal/cmd/network/command.go
@@ -188,6 +188,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			if err := cliapp.RequireFlags(cmd, "domain", "dns-addr", "parse-type"); err != nil {
+				return err
+			}
 			data, _ := cmd.Flags().GetString("data")
 			body, err := cliapp.MergeDataWithFlags(data, cmd, dnsProxyFieldMap)
 			if err != nil {
@@ -292,6 +295,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			if err := cliapp.RequireFlags(cmd, "name", "interface", "addr-pool", "netmask", "gateway", "lease", "phy-ifnames"); err != nil {
+				return err
+			}
 			data, _ := cmd.Flags().GetString("data")
 			body, err := cliapp.MergeDataWithFlags(data, cmd, dhcpFieldMap)
 			if err != nil {
@@ -336,6 +342,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
 				return err
 			}
 			data, _ := cmd.Flags().GetString("data")
@@ -413,6 +422,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			if err := cliapp.RequireFlags(cmd, "name", "ip", "mac", "interface"); err != nil {
+				return err
+			}
 			data, _ := cmd.Flags().GetString("data")
 			body, err := cliapp.MergeDataWithFlags(data, cmd, dhcpStaticFieldMap)
 			if err != nil {
@@ -455,6 +467,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
 				return err
 			}
 			data, _ := cmd.Flags().GetString("data")
@@ -546,6 +561,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		Short:   "Create DHCP access rule",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			if err := cliapp.RequireFlags(cmd, "name", "mac", "comment"); err != nil {
 				return err
 			}
 			data, _ := cmd.Flags().GetString("data")
@@ -744,6 +762,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
+				return err
+			}
 			data, _ := cmd.Flags().GetString("data")
 			body, err := cliapp.MergeDataWithFlags(data, cmd, toggleFieldMap)
 			if err != nil {
@@ -801,6 +822,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			if err := cliapp.RequireFlags(cmd, "name", "vlan-id", "interface", "netmask"); err != nil {
+				return err
+			}
 			data, _ := cmd.Flags().GetString("data")
 			body, err := cliapp.MergeDataWithFlags(data, cmd, vlanFieldMap)
 			if err != nil {
@@ -843,6 +867,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
 				return err
 			}
 			data, _ := cmd.Flags().GetString("data")
@@ -1199,6 +1226,9 @@ func natGroup(app *cliapp.Runtime, use, short, apiPath string, fieldMap map[stri
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
 				return err
 			}
 			data, _ := cmd.Flags().GetString("data")

--- a/internal/cmd/objects/behavior_test.go
+++ b/internal/cmd/objects/behavior_test.go
@@ -83,9 +83,11 @@ func TestIPCreateSendsExpectedJSONBody(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ReadAll() error = %v", err)
 			}
-			if string(body) != `{"address":"10.0.0.1","name":"office-gateway"}` &&
-				string(body) != `{"name":"office-gateway","address":"10.0.0.1"}` {
-				t.Fatalf("body = %q", string(body))
+			bs := string(body)
+			for _, want := range []string{`"group_name":"office-gateway"`, `"group_value":`} {
+				if !bytes.Contains(body, []byte(want)) {
+					t.Fatalf("body missing %s: %s", want, bs)
+				}
 			}
 
 			return jsonResponse(`{"code":0,"message":"created","data":null}`), nil
@@ -93,7 +95,7 @@ func TestIPCreateSendsExpectedJSONBody(t *testing.T) {
 	})
 
 	cmd := New(app)
-	cmd.SetArgs([]string{"ip", "create", "--data", `{"name":"office-gateway","address":"10.0.0.1"}`})
+	cmd.SetArgs([]string{"ip", "create", "--name", "office-gateway", "--value", "10.0.0.1"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}

--- a/internal/cmd/objects/command.go
+++ b/internal/cmd/objects/command.go
@@ -80,6 +80,13 @@ func objectGroup(app *cliapp.Runtime, name, apiPath string, fieldMap map[string]
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			required := []string{"name"}
+			if valueKey != "" {
+				required = append(required, "value")
+			}
+			if err := cliapp.RequireFlags(cmd, required...); err != nil {
+				return err
+			}
 			data, _ := cmd.Flags().GetString("data")
 			body, err := cliapp.MergeDataWithFlags(data, cmd, map[string]string{"name": "group_name"})
 			if err != nil {

--- a/internal/cmd/qos/behavior_test.go
+++ b/internal/cmd/qos/behavior_test.go
@@ -85,7 +85,7 @@ func TestIPCreateSendsExpectedJSONBody(t *testing.T) {
 			}
 			// writeCmd merges createDefaults into the body, so we check key fields.
 			bs := string(body)
-			for _, want := range []string{`"name":"office-cap"`, `"limit":"20M"`, `"protocol":"any"`} {
+			for _, want := range []string{`"tagname":"office-cap"`, `"upload":"20M"`, `"download":"20M"`, `"interface":"wan1"`} {
 				if !bytes.Contains(body, []byte(want)) {
 					t.Fatalf("body missing %s: %s", want, bs)
 				}
@@ -96,7 +96,7 @@ func TestIPCreateSendsExpectedJSONBody(t *testing.T) {
 	})
 
 	cmd := New(app)
-	cmd.SetArgs([]string{"ip", "create", "--data", `{"name":"office-cap","limit":"20M"}`})
+	cmd.SetArgs([]string{"ip", "create", "--name", "office-cap", "--interface", "wan1", "--upload", "20M", "--download", "20M"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}

--- a/internal/cmd/qos/command.go
+++ b/internal/cmd/qos/command.go
@@ -96,13 +96,15 @@ func New(app *cliapp.Runtime) *cobra.Command {
 	}
 
 	qosCmd.AddCommand(qosGroup(app, "ip", "network/qos/ip", addQoSIPFlags, qosIPFieldMap, qosIPAddrFields, qosIPCreateDefaults,
-		[]string{"id", "tagname", "ip_addr", "interface", "protocol", "upload", "download", "enabled"}))
+		[]string{"id", "tagname", "ip_addr", "interface", "protocol", "upload", "download", "enabled"},
+		[]string{"name", "interface", "upload", "download"}))
 	qosCmd.AddCommand(qosGroup(app, "mac", "network/qos/mac", addQoSMACFlags, qosMACFieldMap, qosMACAddrFields, qosMACCreateDefaults,
-		[]string{"id", "tagname", "mac_addr", "interface", "upload", "download", "enabled"}))
+		[]string{"id", "tagname", "mac_addr", "interface", "upload", "download", "enabled"},
+		[]string{"name", "interface", "upload", "download"}))
 	return qosCmd
 }
 
-func qosGroup(app *cliapp.Runtime, name, apiPath string, addFlags func(*cobra.Command), fieldMap map[string]string, addrFields map[string]string, defaults map[string]interface{}, defaultColumns []string) *cobra.Command {
+func qosGroup(app *cliapp.Runtime, name, apiPath string, addFlags func(*cobra.Command), fieldMap map[string]string, addrFields map[string]string, defaults map[string]interface{}, defaultColumns []string, requiredCreateFlags []string) *cobra.Command {
 	group := &cobra.Command{Use: name, Short: "QoS rules based on " + name}
 
 	listCmd := &cobra.Command{
@@ -148,6 +150,15 @@ func qosGroup(app *cliapp.Runtime, name, apiPath string, addFlags func(*cobra.Co
 	createCmd := dataCommandImpl(app, "create", "Create a "+name+" QoS rule", false, addFlags, fieldMap, addrFields, defaults, func(body interface{}, id string) (json.RawMessage, error) {
 		return app.APIClient.Post(cliapp.APIBase+"/"+apiPath, body)
 	})
+	if len(requiredCreateFlags) > 0 {
+		origRunE := createCmd.RunE
+		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := cliapp.RequireFlags(cmd, requiredCreateFlags...); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
 	updateCmd := dataCommandImpl(app, "update ID", "Update a "+name+" QoS rule", true, addFlags, fieldMap, addrFields, nil, func(body interface{}, id string) (json.RawMessage, error) {
 		return app.APIClient.Put(cliapp.APIBase+"/"+apiPath+"/"+id, body)
 	})
@@ -200,6 +211,11 @@ func dataCommandImpl(app *cliapp.Runtime, use, short string, withID bool, addFla
 	c.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := app.RequireAuth(); err != nil {
 			return err
+		}
+		if strings.HasPrefix(use, "toggle") {
+			if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
+				return err
+			}
 		}
 		data, _ := cmd.Flags().GetString("data")
 		body, err := cliapp.MergeDataWithFlags(data, cmd, fieldMap)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -229,6 +229,29 @@ func init() {
 	_ = rootCmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"table", "json", "yaml"}, cobra.ShellCompDirectiveNoFileComp
 	})
+
+	// Reformat cobra's required-flag error to match project convention:
+	// "required flag(s) "x" not set" → "missing required flag: --x"
+	rootCmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		msg := err.Error()
+		const prefix = `required flag(s) `
+		const suffix = ` not set`
+		if strings.HasPrefix(msg, prefix) && strings.HasSuffix(msg, suffix) {
+			inner := strings.TrimPrefix(msg, prefix)
+			inner = strings.TrimSuffix(inner, suffix)
+			// inner looks like: `"name"` or `"name1", "name2"`
+			parts := strings.Split(inner, ", ")
+			flags := make([]string, 0, len(parts))
+			for _, p := range parts {
+				flags = append(flags, "--"+strings.Trim(p, `"`))
+			}
+			if len(flags) == 1 {
+				return &cliapp.ValidationError{Message: "missing required flag: " + flags[0]}
+			}
+			return &cliapp.ValidationError{Message: "missing required flags: " + strings.Join(flags, ", ")}
+		}
+		return &cliapp.ValidationError{Message: msg}
+	})
 }
 
 // isTerminalWriter checks whether w is connected to a terminal.

--- a/internal/cmd/routing/behavior_test.go
+++ b/internal/cmd/routing/behavior_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/ikuaidev/ikuai-cli/internal/api"
@@ -85,7 +86,7 @@ func TestStreamFiveTupleCreateSendsExpectedJSONBody(t *testing.T) {
 			}
 			// writeCmd merges createDefaults into the body, so we check key fields.
 			bs := string(body)
-			for _, want := range []string{`"gateway":"wan2"`, `"name":"office-stream"`, `"protocol":"any"`, `"prio":31`} {
+			for _, want := range []string{`"interface":"wan2"`, `"tagname":"office-stream"`, `"protocol":"any"`, `"prio":31`} {
 				if !bytes.Contains(body, []byte(want)) {
 					t.Fatalf("body missing %s: %s", want, bs)
 				}
@@ -96,7 +97,7 @@ func TestStreamFiveTupleCreateSendsExpectedJSONBody(t *testing.T) {
 	})
 
 	cmd := New(app)
-	cmd.SetArgs([]string{"stream", "five-tuple", "create", "--data", `{"name":"office-stream","gateway":"wan2"}`})
+	cmd.SetArgs([]string{"stream", "five-tuple", "create", "--name", "office-stream", "--interface", "wan2"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -105,6 +106,42 @@ func TestStreamFiveTupleCreateSendsExpectedJSONBody(t *testing.T) {
 	want := "{\"message\":\"created\"}\n"
 	if got != want {
 		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestStaticCreateMissingRequiredFlags(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "tok"}
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"static", "create", "--name", "test"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing required flags")
+	}
+	if !strings.Contains(err.Error(), "missing required flag") {
+		t.Fatalf("error = %q, want it to contain 'missing required flag'", err.Error())
+	}
+}
+
+func TestStreamDomainToggleMissingEnabled(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "tok"}
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"stream", "domain", "toggle", "1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing --enabled")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --enabled") {
+		t.Fatalf("error = %q, want 'missing required flag: --enabled'", err.Error())
 	}
 }
 

--- a/internal/cmd/routing/command.go
+++ b/internal/cmd/routing/command.go
@@ -144,33 +144,38 @@ func New(app *cliapp.Runtime) *cobra.Command {
 	streamCmd := &cobra.Command{Use: "stream", Short: "Traffic shunting rules"}
 	streamCmd.AddCommand(
 		ruleGroup(app, "domain", "Domain-based stream rules", "routing/domain-rules", ruleGroupOpts{
-			fieldMap:       domainFieldMap,
-			addrFields:     domainAddrFields,
-			createDefaults: domainDefaults,
-			defaultColumns: []string{"id", "tagname", "domain", "interface", "src_addr", "prio", "enabled"},
+			fieldMap:            domainFieldMap,
+			addrFields:          domainAddrFields,
+			createDefaults:      domainDefaults,
+			defaultColumns:      []string{"id", "tagname", "domain", "interface", "src_addr", "prio", "enabled"},
+			requiredCreateFlags: []string{"name", "interface"},
 		}),
 		ruleGroup(app, "five-tuple", "5-tuple stream rules (src/dst IP, port, protocol)", "routing/five-tuple-rules", ruleGroupOpts{
-			fieldMap:       fiveTupleFieldMap,
-			addrFields:     fiveTupleAddrFields,
-			createDefaults: fiveTupleDefaults,
-			defaultColumns: []string{"id", "tagname", "src_addr", "dst_addr", "protocol", "dst_port", "interface", "prio", "enabled"},
+			fieldMap:            fiveTupleFieldMap,
+			addrFields:          fiveTupleAddrFields,
+			createDefaults:      fiveTupleDefaults,
+			defaultColumns:      []string{"id", "tagname", "src_addr", "dst_addr", "protocol", "dst_port", "interface", "prio", "enabled"},
+			requiredCreateFlags: []string{"name", "interface"},
 		}),
 		ruleGroup(app, "l7", "L7 application protocol stream rules", "routing/app-protocols", ruleGroupOpts{
-			fieldMap:       l7FieldMap,
-			addrFields:     l7AddrFields,
-			createDefaults: l7Defaults,
-			defaultColumns: []string{"id", "tagname", "app_proto", "interface", "src_addr", "prio", "enabled"},
+			fieldMap:            l7FieldMap,
+			addrFields:          l7AddrFields,
+			createDefaults:      l7Defaults,
+			defaultColumns:      []string{"id", "tagname", "app_proto", "interface", "src_addr", "prio", "enabled"},
+			requiredCreateFlags: []string{"name", "interface"},
 		}),
 		ruleGroup(app, "load-balance", "Load balance rules", "routing/load-balance-rules", ruleGroupOpts{
-			fieldMap:       loadBalanceFieldMap,
-			createDefaults: loadBalanceDefaults,
-			defaultColumns: []string{"id", "tagname", "interface", "mode", "weight", "isp_name", "enabled"},
+			fieldMap:            loadBalanceFieldMap,
+			createDefaults:      loadBalanceDefaults,
+			defaultColumns:      []string{"id", "tagname", "interface", "mode", "weight", "isp_name", "enabled"},
+			requiredCreateFlags: []string{"name", "interface"},
 		}),
 		ruleGroup(app, "updown", "Upstream/downstream rules", "routing/updown", ruleGroupOpts{
-			fieldMap:       updownFieldMap,
-			addrFields:     updownAddrFields,
-			createDefaults: updownDefaults,
-			defaultColumns: []string{"id", "tagname", "upiface", "downiface", "protocol", "src_addr", "enabled"},
+			fieldMap:            updownFieldMap,
+			addrFields:          updownAddrFields,
+			createDefaults:      updownDefaults,
+			defaultColumns:      []string{"id", "tagname", "upiface", "downiface", "protocol", "src_addr", "enabled"},
+			requiredCreateFlags: []string{"name", "upiface", "downiface"},
 		}),
 	)
 	routingCmd.AddCommand(streamCmd)
@@ -222,6 +227,15 @@ func staticGroup(app *cliapp.Runtime) *cobra.Command {
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/routing/static-routes", body)
 		})
+	{
+		origRunE := createCmd.RunE
+		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := cliapp.RequireFlags(cmd, "name", "dst-addr", "gateway", "netmask", "interface"); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
 	updateCmd := writeCmd(app, "update ID", "Update a static route", true, staticFieldMap, nil, nil,
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Put(cliapp.APIBase+"/routing/static-routes/"+id, body)
@@ -242,10 +256,11 @@ func staticGroup(app *cliapp.Runtime) *cobra.Command {
 }
 
 type ruleGroupOpts struct {
-	fieldMap       map[string]string
-	addrFields     map[string]string
-	createDefaults map[string]interface{}
-	defaultColumns []string
+	fieldMap            map[string]string
+	addrFields          map[string]string
+	createDefaults      map[string]interface{}
+	defaultColumns      []string
+	requiredCreateFlags []string
 }
 
 func ruleGroup(app *cliapp.Runtime, use, short, apiPath string, opts ruleGroupOpts) *cobra.Command {
@@ -277,6 +292,15 @@ func ruleGroup(app *cliapp.Runtime, use, short, apiPath string, opts ruleGroupOp
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/"+apiPath, body)
 		})
+	if len(opts.requiredCreateFlags) > 0 {
+		origRunE := createCmd.RunE
+		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := cliapp.RequireFlags(cmd, opts.requiredCreateFlags...); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
 	updateCmd := writeCmd(app, "update ID", "Update a "+use+" rule", true, opts.fieldMap, opts.addrFields, nil,
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Put(cliapp.APIBase+"/"+apiPath+"/"+id, body)
@@ -356,6 +380,11 @@ func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[
 	c.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := app.RequireAuth(); err != nil {
 			return err
+		}
+		if strings.HasPrefix(use, "toggle") {
+			if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
+				return err
+			}
 		}
 		data, _ := cmd.Flags().GetString("data")
 		body, err := cliapp.MergeDataWithFlags(data, cmd, fieldMap)

--- a/internal/cmd/security/behavior_test.go
+++ b/internal/cmd/security/behavior_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/ikuaidev/ikuai-cli/internal/api"
@@ -101,6 +102,24 @@ func TestMACSetModeSendsExpectedJSONBody(t *testing.T) {
 	want := "{\"message\":\"saved\"}\n"
 	if got != want {
 		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestACLCreateMissingRequiredFlags(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "tok"}
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"acl", "create"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing required flags")
+	}
+	if !strings.Contains(err.Error(), "missing required flags") {
+		t.Fatalf("error = %q, want it to contain 'missing required flags'", err.Error())
 	}
 }
 

--- a/internal/cmd/security/command.go
+++ b/internal/cmd/security/command.go
@@ -231,9 +231,10 @@ func New(app *cliapp.Runtime) *cobra.Command {
 	}
 
 	securityCmd.AddCommand(secGroup(app, "acl", "IP ACL rules", "security/acl-rules", true, aclFieldMap, secGroupOpts{
-		createDefaults: aclCreateDefaults,
-		defaultColumns: []string{"id", "src_addr", "dst_addr", "src_port", "dst_port", "tagname", "action", "protocol", "enabled"},
-		addrFields:     aclAddrFields,
+		createDefaults:      aclCreateDefaults,
+		defaultColumns:      []string{"id", "src_addr", "dst_addr", "src_port", "dst_port", "tagname", "action", "protocol", "enabled"},
+		addrFields:          aclAddrFields,
+		requiredCreateFlags: []string{"name", "action", "protocol"},
 	}))
 
 	macCmd := &cobra.Command{Use: "mac", Short: "MAC access control"}
@@ -259,36 +260,44 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			return app.APIClient.Put(cliapp.APIBase+"/security/mac-mode", body)
 		}),
 	)
-	addSecCRUD(app, macCmd, "security/mac-rules", false, macFieldMap, macCreateDefaults, nil, nil)
+	addSecCRUD(app, macCmd, "security/mac-rules", false, macFieldMap, macCreateDefaults, nil, nil, []string{"name", "mac"})
 	securityCmd.AddCommand(macCmd)
 
 	securityCmd.AddCommand(secGroup(app, "l7", "L7 application-layer rules", "security/app-protocols/professional/rules", true, l7FieldMap, secGroupOpts{
-		createDefaults: l7CreateDefaults,
-		addrFields:     l7AddrFields,
+		createDefaults:      l7CreateDefaults,
+		addrFields:          l7AddrFields,
+		requiredCreateFlags: []string{"name", "action", "priority"},
 	}))
 
 	urlCmd := &cobra.Command{Use: "url", Short: "URL filter rules"}
 	urlCmd.AddCommand(
 		secGroup(app, "black", "URL blacklist rules", "security/url-black/rules", false, urlBlackFieldMap, secGroupOpts{
-			createDefaults: urlBlackCreateDefaults,
-			addrFields:     urlBlackAddrFields,
+			createDefaults:      urlBlackCreateDefaults,
+			addrFields:          urlBlackAddrFields,
+			requiredCreateFlags: []string{"name", "mode"},
 		}),
 		secGroup(app, "keywords", "URL keyword rules", "security/url-keywords/rules", false, urlKeywordsFieldMap, secGroupOpts{
-			defaultColumns: []string{"id", "tagname", "mode", "src_url", "ori_keyword", "rep_keyword", "hit_rate", "prio", "enabled"},
+			defaultColumns:      []string{"id", "tagname", "mode", "src_url", "ori_keyword", "rep_keyword", "hit_rate", "prio", "enabled"},
+			requiredCreateFlags: []string{"name", "mode", "src-url", "ori-keyword", "rep-keyword", "hit-rate", "priority"},
 		}),
 		secGroup(app, "redirect", "URL redirect rules", "security/url-redirect/rules", false, urlRedirectFieldMap, secGroupOpts{
-			defaultColumns: []string{"id", "tagname", "mode", "src_url", "dst_url", "hit_rate", "prio", "enabled"},
+			defaultColumns:      []string{"id", "tagname", "mode", "src_url", "dst_url", "hit_rate", "prio", "enabled"},
+			requiredCreateFlags: []string{"name", "mode", "src-url", "dst-url", "hit-rate", "priority"},
 		}),
 		secGroup(app, "replace", "URL replace rules", "security/url-replace/rules", false, urlReplaceFieldMap, secGroupOpts{
-			defaultColumns: []string{"id", "tagname", "mode", "src_url", "param_keyword", "rep_keyword", "hit_rate", "prio", "enabled"},
+			defaultColumns:      []string{"id", "tagname", "mode", "src_url", "param_keyword", "rep_keyword", "hit_rate", "prio", "enabled"},
+			requiredCreateFlags: []string{"name", "mode", "src-url", "param-keyword", "rep-keyword", "hit-rate", "priority"},
 		}),
 	)
 	securityCmd.AddCommand(urlCmd)
 
-	securityCmd.AddCommand(secGroup(app, "domain-blacklist", "Domain blacklist rules", "security/domain-blacklist/rules", false, domainBlacklistFieldMap))
+	securityCmd.AddCommand(secGroup(app, "domain-blacklist", "Domain blacklist rules", "security/domain-blacklist/rules", false, domainBlacklistFieldMap, secGroupOpts{
+		requiredCreateFlags: []string{"name", "domain-group"},
+	}))
 	securityCmd.AddCommand(secGroup(app, "peerconn", "Peer connection rules", "security/peerconn/rules", false, peerconnFieldMap, secGroupOpts{
-		createDefaults: peerconnCreateDefaults,
-		addrFields:     peerconnAddrFields,
+		createDefaults:      peerconnCreateDefaults,
+		addrFields:          peerconnAddrFields,
+		requiredCreateFlags: []string{"name", "limits", "protocol"},
 	}))
 	securityCmd.AddCommand(secGroup(app, "terminals", "Terminal device annotations", "security/terminals", false, terminalsFieldMap))
 
@@ -325,9 +334,10 @@ func New(app *cliapp.Runtime) *cobra.Command {
 }
 
 type secGroupOpts struct {
-	createDefaults map[string]interface{}
-	defaultColumns []string
-	addrFields     map[string]string // CLI flag → API field for address/port nested objects.
+	createDefaults      map[string]interface{}
+	defaultColumns      []string
+	addrFields          map[string]string // CLI flag → API field for address/port nested objects.
+	requiredCreateFlags []string
 }
 
 func secGroup(app *cliapp.Runtime, use, short, apiPath string, withGet bool, fieldMap map[string]string, opts ...secGroupOpts) *cobra.Command {
@@ -336,11 +346,11 @@ func secGroup(app *cliapp.Runtime, use, short, apiPath string, withGet bool, fie
 	if len(opts) > 0 {
 		o = opts[0]
 	}
-	addSecCRUD(app, grp, apiPath, withGet, fieldMap, o.createDefaults, o.defaultColumns, o.addrFields)
+	addSecCRUD(app, grp, apiPath, withGet, fieldMap, o.createDefaults, o.defaultColumns, o.addrFields, o.requiredCreateFlags)
 	return grp
 }
 
-func addSecCRUD(app *cliapp.Runtime, grp *cobra.Command, apiPath string, withGet bool, fieldMap map[string]string, createDefaults map[string]interface{}, defaultColumns []string, addrFields map[string]string) {
+func addSecCRUD(app *cliapp.Runtime, grp *cobra.Command, apiPath string, withGet bool, fieldMap map[string]string, createDefaults map[string]interface{}, defaultColumns []string, addrFields map[string]string, requiredCreateFlags []string) {
 	name := grp.Use
 	listCmd := &cobra.Command{
 		Use:     "list",
@@ -368,6 +378,15 @@ func addSecCRUD(app *cliapp.Runtime, grp *cobra.Command, apiPath string, withGet
 	createCmd := secWriteCmd(app, "create", "Create a "+name+" rule", false, fieldMap, createDefaults, addrFields, func(body interface{}, id string) (json.RawMessage, error) {
 		return app.APIClient.Post(cliapp.APIBase+"/"+apiPath, body)
 	})
+	if len(requiredCreateFlags) > 0 {
+		origRunE := createCmd.RunE
+		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := cliapp.RequireFlags(cmd, requiredCreateFlags...); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
 	updateCmd := secWriteCmd(app, "update ID", "Update a "+name+" rule", true, fieldMap, nil, addrFields, func(body interface{}, id string) (json.RawMessage, error) {
 		return app.APIClient.Put(cliapp.APIBase+"/"+apiPath+"/"+id, body)
 	})

--- a/internal/cmd/system/command.go
+++ b/internal/cmd/system/command.go
@@ -121,6 +121,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			if err := cliapp.RequireFlags(cmd, "name", "time", "strategy", "cycle-time"); err != nil {
+				return err
+			}
 			data, _ := cmd.Flags().GetString("data")
 			body, err := cliapp.MergeDataWithFlags(data, cmd, schedulesFieldMap)
 			if err != nil {
@@ -169,6 +172,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
 				return err
 			}
 			data, _ := cmd.Flags().GetString("data")

--- a/internal/cmd/users/behavior_test.go
+++ b/internal/cmd/users/behavior_test.go
@@ -85,7 +85,7 @@ func TestAccountsCreateSendsExpectedJSONBody(t *testing.T) {
 			}
 			// writeCmd merges createDefaults into the body, so we check key fields.
 			bs := string(body)
-			for _, want := range []string{`"username":"alice"`, `"password":"secret"`, `"ppptype":"any"`, `"share":1`} {
+			for _, want := range []string{`"username":"alice"`, `"passwd":"secret"`, `"ppptype":"any"`, `"share":1`} {
 				if !bytes.Contains(body, []byte(want)) {
 					t.Fatalf("body missing %s: %s", want, bs)
 				}
@@ -96,7 +96,7 @@ func TestAccountsCreateSendsExpectedJSONBody(t *testing.T) {
 	})
 
 	cmd := New(app)
-	cmd.SetArgs([]string{"accounts", "create", "--data", `{"username":"alice","password":"secret"}`})
+	cmd.SetArgs([]string{"accounts", "create", "--username", "alice", "--password", "secret"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}

--- a/internal/cmd/users/command.go
+++ b/internal/cmd/users/command.go
@@ -131,13 +131,23 @@ func accountsGroup(app *cliapp.Runtime) *cobra.Command {
 	}
 	cliapp.AddListFlags(listCmd)
 
+	createCmd := writeCmd(app, "create", "Create a user account", false, accountFieldMap, nil, accountDefaults,
+		func(body interface{}, id string) (json.RawMessage, error) {
+			return app.APIClient.Post(cliapp.APIBase+"/auth/users", body)
+		})
+	{
+		origRunE := createCmd.RunE
+		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := cliapp.RequireFlags(cmd, "username", "password"); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
 	group.AddCommand(
 		listCmd,
 		getByIDCmd(app, "get ID", "Get a single user account", "/auth/users/"),
-		writeCmd(app, "create", "Create a user account", false, accountFieldMap, nil, accountDefaults,
-			func(body interface{}, id string) (json.RawMessage, error) {
-				return app.APIClient.Post(cliapp.APIBase+"/auth/users", body)
-			}),
+		createCmd,
 		writeCmd(app, "update ID", "Update a user account", true, accountFieldMap, nil, nil,
 			func(body interface{}, id string) (json.RawMessage, error) {
 				return app.APIClient.Put(cliapp.APIBase+"/auth/users/"+id, body)
@@ -170,13 +180,23 @@ func packagesGroup(app *cliapp.Runtime) *cobra.Command {
 	}
 	cliapp.AddListFlags(listCmd)
 
+	pkgCreateCmd := writeCmd(app, "create", "Create a package", false, packageFieldMap, nil, packageDefaults,
+		func(body interface{}, id string) (json.RawMessage, error) {
+			return app.APIClient.Post(cliapp.APIBase+"/auth/packages", body)
+		})
+	{
+		origRunE := pkgCreateCmd.RunE
+		pkgCreateCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := cliapp.RequireFlags(cmd, "name", "time", "price", "up-speed", "down-speed"); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
 	group.AddCommand(
 		listCmd,
 		getByIDCmd(app, "get ID", "Get a single package", "/auth/packages/"),
-		writeCmd(app, "create", "Create a package", false, packageFieldMap, nil, packageDefaults,
-			func(body interface{}, id string) (json.RawMessage, error) {
-				return app.APIClient.Post(cliapp.APIBase+"/auth/packages", body)
-			}),
+		pkgCreateCmd,
 		writeCmd(app, "update ID", "Update a package", true, packageFieldMap, nil, nil,
 			func(body interface{}, id string) (json.RawMessage, error) {
 				return app.APIClient.Put(cliapp.APIBase+"/auth/packages/"+id, body)
@@ -259,6 +279,11 @@ func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[
 	c.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := app.RequireAuth(); err != nil {
 			return err
+		}
+		if strings.HasPrefix(use, "toggle") {
+			if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
+				return err
+			}
 		}
 		data, _ := cmd.Flags().GetString("data")
 		body, err := cliapp.MergeDataWithFlags(data, cmd, fieldMap)

--- a/internal/cmd/vpn/behavior_test.go
+++ b/internal/cmd/vpn/behavior_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/ikuaidev/ikuai-cli/internal/api"
@@ -85,7 +86,7 @@ func TestWireGuardPeerCreateSendsExpectedJSONBody(t *testing.T) {
 			}
 			// writeCmd merges createDefaults into the body, so we check key fields.
 			bs := string(body)
-			for _, want := range []string{`"name":"peer-a"`, `"public_key":"pub-key"`} {
+			for _, want := range []string{`"peer_publickey":"pub-key"`, `"allowips":"10.0.0.0/24"`, `"interface":"wg0"`} {
 				if !bytes.Contains(body, []byte(want)) {
 					t.Fatalf("body missing %s: %s", want, bs)
 				}
@@ -96,7 +97,7 @@ func TestWireGuardPeerCreateSendsExpectedJSONBody(t *testing.T) {
 	})
 
 	cmd := New(app)
-	cmd.SetArgs([]string{"wireguard", "peer-create", "tunnel-1", "--data", `{"name":"peer-a","public_key":"pub-key"}`})
+	cmd.SetArgs([]string{"wireguard", "peer-create", "tunnel-1", "--public-key", "pub-key", "--allow-ips", "10.0.0.0/24", "--interface", "wg0"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -105,6 +106,24 @@ func TestWireGuardPeerCreateSendsExpectedJSONBody(t *testing.T) {
 	want := "{\"message\":\"created\"}\n"
 	if got != want {
 		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestPPTPClientCreateMissingRequiredFlags(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "tok"}
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"pptp", "client-create", "--name", "test"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing required flags")
+	}
+	if !strings.Contains(err.Error(), "missing required flag") {
+		t.Fatalf("error = %q, want it to contain 'missing required flag'", err.Error())
 	}
 }
 

--- a/internal/cmd/vpn/command.go
+++ b/internal/cmd/vpn/command.go
@@ -222,20 +222,24 @@ func New(app *cliapp.Runtime) *cobra.Command {
 	}
 
 	vpnCmd.AddCommand(vpnServerGroup(app, "pptp", "vpn/pptp", pptpClientFieldMap, pptpClientDefaults,
-		[]string{"id", "name", "server", "username", "interface", "enabled"}, pptpServerFieldMap))
+		[]string{"id", "name", "server", "username", "interface", "enabled"}, pptpServerFieldMap,
+		[]string{"name", "server", "username", "password", "interface"}))
 	vpnCmd.AddCommand(vpnServerGroup(app, "l2tp", "vpn/l2tp", l2tpClientFieldMap, l2tpClientDefaults,
-		[]string{"id", "name", "server", "username", "interface", "enabled"}, l2tpServerFieldMap))
+		[]string{"id", "name", "server", "username", "interface", "enabled"}, l2tpServerFieldMap,
+		[]string{"name", "server", "username", "password", "interface"}))
 	vpnCmd.AddCommand(vpnServerGroup(app, "openvpn", "vpn/openvpn", openvpnClientFieldMap, openvpnClientDefaults,
-		[]string{"id", "name", "remote_addr", "remote_port", "proto", "interface", "enabled"}, openvpnServerFieldMap))
+		[]string{"id", "name", "remote_addr", "remote_port", "proto", "interface", "enabled"}, openvpnServerFieldMap,
+		[]string{"name", "remote-addr", "interface"}))
 	vpnCmd.AddCommand(vpnServerGroup(app, "ikev2", "vpn/ikev2", ikev2ClientFieldMap, ikev2ClientDefaults,
-		[]string{"id", "name", "remote_addr", "interface", "authby", "enabled"}, ikev2ServerFieldMap))
+		[]string{"id", "name", "remote_addr", "interface", "authby", "enabled"}, ikev2ServerFieldMap,
+		[]string{"name", "remote-addr", "interface", "left-id"}))
 	vpnCmd.AddCommand(ipsecGroup(app))
 	vpnCmd.AddCommand(wireguardGroup(app))
 
 	return vpnCmd
 }
 
-func vpnServerGroup(app *cliapp.Runtime, name, apiPath string, clientFieldMap map[string]string, clientDefaults map[string]interface{}, defaultColumns []string, serverFieldMap map[string]string) *cobra.Command {
+func vpnServerGroup(app *cliapp.Runtime, name, apiPath string, clientFieldMap map[string]string, clientDefaults map[string]interface{}, defaultColumns []string, serverFieldMap map[string]string, requiredCreateFlags []string) *cobra.Command {
 	grp := &cobra.Command{Use: name, Short: name + " VPN"}
 
 	getCmd := &cobra.Command{
@@ -288,6 +292,15 @@ func vpnServerGroup(app *cliapp.Runtime, name, apiPath string, clientFieldMap ma
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/"+apiPath+"/clients", body)
 		})
+	if len(requiredCreateFlags) > 0 {
+		origRunE := clientCreateCmd.RunE
+		clientCreateCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := cliapp.RequireFlags(cmd, requiredCreateFlags...); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
 	clientUpdateCmd := writeCmd(app, "client-update ID", "Update a "+name+" client", true, clientFieldMap, nil, nil,
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Put(cliapp.APIBase+"/"+apiPath+"/clients/"+id, body)
@@ -321,12 +334,22 @@ func ipsecGroup(app *cliapp.Runtime) *cobra.Command {
 	}
 	cliapp.AddListFlags(clientsCmd)
 
+	createCmd := writeCmd(app, "client-create", "Create an IPSec client", false, ipsecClientFieldMap, nil, ipsecClientDefaults,
+		func(body interface{}, id string) (json.RawMessage, error) {
+			return app.APIClient.Post(cliapp.APIBase+"/vpn/ipsec/clients", body)
+		})
+	{
+		origRunE := createCmd.RunE
+		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := cliapp.RequireFlags(cmd, "name", "interface", "left-subnet", "right-subnet"); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
 	grp.AddCommand(
 		clientsCmd,
-		writeCmd(app, "client-create", "Create an IPSec client", false, ipsecClientFieldMap, nil, ipsecClientDefaults,
-			func(body interface{}, id string) (json.RawMessage, error) {
-				return app.APIClient.Post(cliapp.APIBase+"/vpn/ipsec/clients", body)
-			}),
+		createCmd,
 		writeCmd(app, "client-update ID", "Update an IPSec client", true, ipsecClientFieldMap, nil, nil,
 			func(body interface{}, id string) (json.RawMessage, error) {
 				return app.APIClient.Put(cliapp.APIBase+"/vpn/ipsec/clients/"+id, body)
@@ -388,13 +411,29 @@ func wireguardGroup(app *cliapp.Runtime) *cobra.Command {
 	wgCreateFieldMap["private-key"] = "local_privatekey"
 	wgCreateFieldMap["public-key"] = "local_publickey"
 
+	// WireGuard tunnel create has no RequireFlags here — local_privatekey/local_publickey
+	// are B2-class missing fields tracked separately, not in this validation pass.
+	wgCreateCmd := writeCmd(app, "create", "Create a WireGuard tunnel", false, wgCreateFieldMap, nil, wireguardDefaults,
+		func(body interface{}, id string) (json.RawMessage, error) {
+			return app.APIClient.Post(cliapp.APIBase+"/vpn/wireguard", body)
+		})
+	peerCreateCmd := writeCmd(app, "peer-create ID", "Create a peer on a WireGuard tunnel", true, wireguardPeerFieldMap, nil, wireguardPeerDefaults,
+		func(body interface{}, id string) (json.RawMessage, error) {
+			return app.APIClient.Post(cliapp.APIBase+"/vpn/wireguard/"+id+"/peers", body)
+		})
+	{
+		origRunE := peerCreateCmd.RunE
+		peerCreateCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := cliapp.RequireFlags(cmd, "public-key", "allow-ips", "interface"); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
 	grp.AddCommand(
 		listCmd,
 		getByIDCmd(app, "get ID", "Get a WireGuard tunnel", "/vpn/wireguard/"),
-		writeCmd(app, "create", "Create a WireGuard tunnel", false, wgCreateFieldMap, nil, wireguardDefaults,
-			func(body interface{}, id string) (json.RawMessage, error) {
-				return app.APIClient.Post(cliapp.APIBase+"/vpn/wireguard", body)
-			}),
+		wgCreateCmd,
 		writeCmd(app, "update ID", "Update a WireGuard tunnel", true, wireguardFieldMap, nil, nil,
 			func(body interface{}, id string) (json.RawMessage, error) {
 				return app.APIClient.Put(cliapp.APIBase+"/vpn/wireguard/"+id, body)
@@ -405,10 +444,7 @@ func wireguardGroup(app *cliapp.Runtime) *cobra.Command {
 			}),
 		deleteByIDCmd(app, "delete ID", "Delete a WireGuard tunnel", "/vpn/wireguard/"),
 		peersListCmd,
-		writeCmd(app, "peer-create ID", "Create a peer on a WireGuard tunnel", true, wireguardPeerFieldMap, nil, wireguardPeerDefaults,
-			func(body interface{}, id string) (json.RawMessage, error) {
-				return app.APIClient.Post(cliapp.APIBase+"/vpn/wireguard/"+id+"/peers", body)
-			}),
+		peerCreateCmd,
 		peerDeleteCmd(app),
 	)
 	return grp
@@ -513,6 +549,11 @@ func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[
 	c.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := app.RequireAuth(); err != nil {
 			return err
+		}
+		if strings.HasPrefix(use, "toggle") {
+			if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
+				return err
+			}
 		}
 		data, _ := cmd.Flags().GetString("data")
 		body, err := cliapp.MergeDataWithFlags(data, cmd, fieldMap)

--- a/internal/cmd/wireless/command.go
+++ b/internal/cmd/wireless/command.go
@@ -56,26 +56,29 @@ func New(app *cliapp.Runtime) *cobra.Command {
 	}
 
 	wirelessCmd.AddCommand(ruleGroup(app, "blacklist", "Wireless access control (blacklist)", "wireless/access-control/rules", ruleGroupOpts{
-		fieldMap:       blacklistFieldMap,
-		addrFields:     blacklistAddrFields,
-		createDefaults: blacklistDefaults,
-		defaultColumns: []string{"id", "tagname", "mode", "lmac", "lssid", "lap", "enabled"},
+		fieldMap:            blacklistFieldMap,
+		addrFields:          blacklistAddrFields,
+		createDefaults:      blacklistDefaults,
+		defaultColumns:      []string{"id", "tagname", "mode", "lmac", "lssid", "lap", "enabled"},
+		requiredCreateFlags: []string{"name", "ap"},
 	}))
 	wirelessCmd.AddCommand(ruleGroup(app, "vlan", "Wireless VLAN rules", "wireless/vlan/rules", ruleGroupOpts{
-		fieldMap:       vlanFieldMap,
-		addrFields:     vlanAddrFields,
-		createDefaults: vlanDefaults,
-		defaultColumns: []string{"id", "tagname", "vlanid", "lmac", "lssid", "enabled"},
+		fieldMap:            vlanFieldMap,
+		addrFields:          vlanAddrFields,
+		createDefaults:      vlanDefaults,
+		defaultColumns:      []string{"id", "tagname", "vlanid", "lmac", "lssid", "enabled"},
+		requiredCreateFlags: []string{"name", "vlan-id"},
 	}))
 	wirelessCmd.AddCommand(acGroup(app))
 	return wirelessCmd
 }
 
 type ruleGroupOpts struct {
-	fieldMap       map[string]string
-	addrFields     map[string]string
-	createDefaults map[string]interface{}
-	defaultColumns []string
+	fieldMap            map[string]string
+	addrFields          map[string]string
+	createDefaults      map[string]interface{}
+	defaultColumns      []string
+	requiredCreateFlags []string
 }
 
 func ruleGroup(app *cliapp.Runtime, use, short, apiPath string, opts ruleGroupOpts) *cobra.Command {
@@ -108,6 +111,15 @@ func ruleGroup(app *cliapp.Runtime, use, short, apiPath string, opts ruleGroupOp
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/"+apiPath, body)
 		})
+	if len(opts.requiredCreateFlags) > 0 {
+		origRunE := createCmd.RunE
+		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := cliapp.RequireFlags(cmd, opts.requiredCreateFlags...); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
 	updateCmd := writeCmd(app, "update ID", "Update a "+short, true, opts.fieldMap, opts.addrFields, nil,
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Put(cliapp.APIBase+"/"+apiPath+"/"+id, body)
@@ -313,6 +325,11 @@ func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[
 	c.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := app.RequireAuth(); err != nil {
 			return err
+		}
+		if strings.HasPrefix(use, "toggle") {
+			if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
+				return err
+			}
 		}
 		data, _ := cmd.Flags().GetString("data")
 		body, err := cliapp.MergeDataWithFlags(data, cmd, fieldMap)


### PR DESCRIPTION
…le commands

Add RequireFlags helper and SetFlagErrorFunc to produce clear error messages (missing required flag: --name) instead of vague API 3001 errors.

## Summary

Describe the change in one or two sentences.

## Changes

- 

## Verification

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make build`

## Docs

- [ ] README updated if command behavior changed

## Notes

Anything reviewers should pay attention to.
