### PR TITLE
fix: 客户端必填参数校验 + createDefaults 补齐

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -188,10 +188,31 @@ ikuai-cli wireless vlan list
 ## Advanced
 
 ```bash
+# FTP
 ikuai-cli advanced ftp config-get
-ikuai-cli advanced http config-get
+ikuai-cli advanced ftp config-set --open-ftp 1 --ftp-port 21 --ftp-access 1
+ikuai-cli advanced ftp list
+ikuai-cli advanced ftp create --username "user1" --password "pass" --permission rw --home-dir "/sda1"
+ikuai-cli advanced ftp toggle <ID> --enabled no
+ikuai-cli advanced ftp delete <ID>
+
+# HTTP
+ikuai-cli advanced http list
+ikuai-cli advanced http create --name "www" --port 8080 --ssl 0 --autoindex 0 --download 0 --home-dir "/sda1"
+ikuai-cli advanced http toggle <ID> --enabled no
+ikuai-cli advanced http delete <ID>
+
+# Samba
 ikuai-cli advanced samba config-get
-ikuai-cli advanced snmpd config-get
+ikuai-cli advanced samba config-set --enabled yes --workgroup WORKGROUP
+ikuai-cli advanced samba list
+ikuai-cli advanced samba create --name "share1" --username "user1" --password "pass" --permission rw --guest yes --home-dir "/sda1"
+ikuai-cli advanced samba toggle <ID> --enabled no
+ikuai-cli advanced samba delete <ID>
+
+# SNMPD
+ikuai-cli advanced snmpd get
+ikuai-cli advanced snmpd set --enabled yes --listen-port 161 --version 2 --community public
 ```
 
 ## Auth Server

--- a/internal/cmd/advanced/command.go
+++ b/internal/cmd/advanced/command.go
@@ -29,15 +29,17 @@ var httpFieldMap = map[string]string{
 	"autoindex":   "autoindex",
 	"download":    "download",
 	"home-dir":    "home_dir",
+	"access":      "access",
 	"enabled":     "enabled",
 }
 
 var sambaFieldMap = map[string]string{
-	"name":       "tagname",
+	"name":       "name",
 	"username":   "username",
 	"password":   "passwd",
 	"permission": "perm",
 	"guest":      "guest",
+	"home-dir":   "home_dir",
 	"enabled":    "enabled",
 }
 
@@ -57,10 +59,38 @@ var sambaConfigFieldMap = map[string]string{
 
 var snmpdFieldMap = map[string]string{
 	"listen-port": "listen_port",
+	"syslocation": "syslocation",
+	"syscontact":  "syscontact",
+	"sysname":     "sysname",
 	"version":     "version",
 	"community":   "community",
+	"source":      "source",
+	"rw":          "rw",
 	"username":    "username",
+	"security":    "security",
+	"auth-proto":  "auth_proto",
+	"auth-pass":   "auth_pass",
+	"priv-proto":  "priv_proto",
+	"priv-pass":   "priv_pass",
 	"enabled":     "enabled",
+}
+
+// ---------- create defaults ----------
+
+var ftpCreateDefaults = map[string]interface{}{
+	"enabled":  "yes",
+	"upload":   0,
+	"download": 0,
+}
+
+var httpCreateDefaults = map[string]interface{}{
+	"enabled": "yes",
+	"access":  1,
+}
+
+var sambaCreateDefaults = map[string]interface{}{
+	"enabled":    "yes",
+	"browseable": "",
 }
 
 // ---------- flag adders ----------
@@ -80,19 +110,21 @@ func addHTTPFlags(cmd *cobra.Command) {
 	cmd.Flags().String("name", "", "Account name (tagname)")
 	cmd.Flags().String("port", "", "HTTP listen port")
 	cmd.Flags().String("server-name", "", "Server name")
-	cmd.Flags().String("ssl", "", "SSL on/off")
-	cmd.Flags().String("autoindex", "", "Enable directory listing")
-	cmd.Flags().String("download", "", "Download bandwidth limit")
-	cmd.Flags().String("home-dir", "", "Home directory")
+	cmd.Flags().String("ssl", "", "SSL on/off (0=off, 1=on)")
+	cmd.Flags().String("autoindex", "", "Enable directory listing (0=off, 1=on)")
+	cmd.Flags().String("download", "", "Download bandwidth limit (KByte/s, 0=unlimited)")
+	cmd.Flags().String("home-dir", "", "Home directory path")
+	cmd.Flags().String("access", "", "WAN access (0=deny, 1=allow)")
 	cliapp.AddEnabledFlag(cmd)
 }
 
 func addSambaFlags(cmd *cobra.Command) {
-	cmd.Flags().String("name", "", "Account name (tagname)")
+	cmd.Flags().String("name", "", "Share name")
 	cmd.Flags().String("username", "", "Samba username")
 	cmd.Flags().String("password", "", "Samba password")
-	cmd.Flags().String("permission", "", "Permission level")
+	cmd.Flags().String("permission", "", "Permission (rw/ro)")
 	cmd.Flags().String("guest", "", "Guest access (yes/no)")
+	cmd.Flags().String("home-dir", "", "Share directory path")
 	cliapp.AddEnabledFlag(cmd)
 }
 
@@ -110,10 +142,20 @@ func addSambaConfigFlags(cmd *cobra.Command) {
 }
 
 func addSNMPDFlags(cmd *cobra.Command) {
-	cmd.Flags().String("listen-port", "", "SNMPD listen port")
-	cmd.Flags().String("version", "", "SNMP version")
-	cmd.Flags().String("community", "", "SNMP community string")
-	cmd.Flags().String("username", "", "SNMP username")
+	cmd.Flags().String("listen-port", "", "SNMPD listen port (2-65535)")
+	cmd.Flags().String("syslocation", "", "System location")
+	cmd.Flags().String("syscontact", "", "System contact")
+	cmd.Flags().String("sysname", "", "System name")
+	cmd.Flags().String("version", "", "SNMP version (2 or 3)")
+	cmd.Flags().String("community", "", "Community string (v2)")
+	cmd.Flags().String("source", "", "Allowed IP/subnet")
+	cmd.Flags().String("rw", "", "Read/write permission (ro/rw)")
+	cmd.Flags().String("username", "", "Username (v3)")
+	cmd.Flags().String("security", "", "Security level (authNoPriv/authPriv)")
+	cmd.Flags().String("auth-proto", "", "Auth protocol (MD5/SHA)")
+	cmd.Flags().String("auth-pass", "", "Auth password (8-30 chars)")
+	cmd.Flags().String("priv-proto", "", "Privacy protocol (DES/AES)")
+	cmd.Flags().String("priv-pass", "", "Privacy password (8-30 chars)")
 	cliapp.AddEnabledFlag(cmd)
 }
 
@@ -125,21 +167,24 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		Short: "Advanced services",
 	}
 
-	advancedCmd.AddCommand(userGroup(app, "http", "HTTP server user management", "advanced-service/http-users", "", "", addHTTPFlags, httpFieldMap,
-		[]string{"name", "port", "ssl", "autoindex", "download", "home-dir"}))
-	advancedCmd.AddCommand(serviceGroup(app, "ftp", "FTP server management", "advanced-service/ftp-config", "advanced-service/ftp-users", addFTPFlags, ftpFieldMap, addFTPConfigFlags, ftpConfigFieldMap,
-		[]string{"username", "password", "permission", "home-dir"}))
-	advancedCmd.AddCommand(serviceGroup(app, "samba", "Samba share management", "advanced-service/samba-config", "advanced-service/samba-users", addSambaFlags, sambaFieldMap, addSambaConfigFlags, sambaConfigFieldMap,
-		[]string{"name", "username", "password", "permission", "guest"}))
+	advancedCmd.AddCommand(userGroup(app, "http", "HTTP server user management", "advanced-service/http-users", "", "", addHTTPFlags, httpFieldMap, httpCreateDefaults,
+		[]string{"name", "port", "ssl", "autoindex", "download", "home-dir"},
+		[]string{"id", "tagname", "http_port", "ssl_on", "home_dir", "download", "enabled"}))
+	advancedCmd.AddCommand(serviceGroup(app, "ftp", "FTP server management", "advanced-service/ftp-config", "advanced-service/ftp-users", addFTPFlags, ftpFieldMap, addFTPConfigFlags, ftpConfigFieldMap, ftpCreateDefaults,
+		[]string{"username", "password", "permission", "home-dir"},
+		[]string{"id", "username", "permission", "home_dir", "upload", "download", "enabled"}))
+	advancedCmd.AddCommand(serviceGroup(app, "samba", "Samba share management", "advanced-service/samba-config", "advanced-service/samba-users", addSambaFlags, sambaFieldMap, addSambaConfigFlags, sambaConfigFieldMap, sambaCreateDefaults,
+		[]string{"name", "username", "password", "permission", "guest", "home-dir"},
+		[]string{"id", "name", "username", "perm", "guest", "home_dir", "enabled"}))
 	advancedCmd.AddCommand(snmpdGroup(app))
 	return advancedCmd
 }
 
-func userGroup(app *cliapp.Runtime, use, short, userAPIPath, configGetPath, configSetPath string, addFlags func(*cobra.Command), fieldMap map[string]string, requiredCreateFlags []string) *cobra.Command {
-	return userGroupWithConfig(app, use, short, userAPIPath, configGetPath, configSetPath, addFlags, fieldMap, nil, nil, requiredCreateFlags)
+func userGroup(app *cliapp.Runtime, use, short, userAPIPath, configGetPath, configSetPath string, addFlags func(*cobra.Command), fieldMap map[string]string, createDefaults map[string]interface{}, requiredCreateFlags []string, defaultColumns []string) *cobra.Command {
+	return userGroupWithConfig(app, use, short, userAPIPath, configGetPath, configSetPath, addFlags, fieldMap, nil, nil, createDefaults, requiredCreateFlags, defaultColumns)
 }
 
-func userGroupWithConfig(app *cliapp.Runtime, use, short, userAPIPath, configGetPath, configSetPath string, addFlags func(*cobra.Command), fieldMap map[string]string, cfgAddFlags func(*cobra.Command), cfgFieldMap map[string]string, requiredCreateFlags []string) *cobra.Command {
+func userGroupWithConfig(app *cliapp.Runtime, use, short, userAPIPath, configGetPath, configSetPath string, addFlags func(*cobra.Command), fieldMap map[string]string, cfgAddFlags func(*cobra.Command), cfgFieldMap map[string]string, createDefaults map[string]interface{}, requiredCreateFlags []string, defaultColumns []string) *cobra.Command {
 	group := &cobra.Command{Use: use, Short: short}
 
 	if configGetPath != "" && configSetPath != "" {
@@ -159,7 +204,7 @@ func userGroupWithConfig(app *cliapp.Runtime, use, short, userAPIPath, configGet
 					return nil
 				},
 			},
-			dataCmd(app, "config-set", "Update "+use+" server configuration", cfgAddFlags, cfgFieldMap, func(body interface{}, id string) (json.RawMessage, error) {
+			dataCmd(app, "config-set", "Update "+use+" server configuration", cfgAddFlags, cfgFieldMap, nil, func(body interface{}, id string) (json.RawMessage, error) {
 				return app.APIClient.Put(cliapp.APIBase+"/"+configSetPath, body)
 			}),
 		)
@@ -173,6 +218,9 @@ func userGroupWithConfig(app *cliapp.Runtime, use, short, userAPIPath, configGet
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			if len(defaultColumns) > 0 {
+				app.DefaultColumns = defaultColumns
+			}
 			page, pageSize, filter, order, orderBy := cliapp.GetListParams(cmd)
 			raw, err := app.APIClient.Get(cliapp.APIBase+"/"+userAPIPath,
 				cliapp.ListParams(page, pageSize, filter, order, orderBy))
@@ -185,7 +233,7 @@ func userGroupWithConfig(app *cliapp.Runtime, use, short, userAPIPath, configGet
 	}
 	cliapp.AddListFlags(listCmd)
 
-	createCmd := dataCmd(app, "create", "Create a "+use+" user", addFlags, fieldMap, func(body interface{}, id string) (json.RawMessage, error) {
+	createCmd := dataCmd(app, "create", "Create a "+use+" user", addFlags, fieldMap, createDefaults, func(body interface{}, id string) (json.RawMessage, error) {
 		return app.APIClient.Post(cliapp.APIBase+"/"+userAPIPath, body)
 	})
 	if len(requiredCreateFlags) > 0 {
@@ -199,7 +247,6 @@ func userGroupWithConfig(app *cliapp.Runtime, use, short, userAPIPath, configGet
 	}
 	group.AddCommand(
 		listCmd,
-		getByIDCmd(app, "get ID", "Get a "+use+" user", "/"+userAPIPath+"/"),
 		createCmd,
 		dataCmdWithID(app, "update ID", "Update a "+use+" user", addFlags, fieldMap, func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Put(cliapp.APIBase+"/"+userAPIPath+"/"+id, body)
@@ -213,8 +260,8 @@ func userGroupWithConfig(app *cliapp.Runtime, use, short, userAPIPath, configGet
 	return group
 }
 
-func serviceGroup(app *cliapp.Runtime, use, short, configAPIPath, userAPIPath string, addFlags func(*cobra.Command), fieldMap map[string]string, configAddFlags func(*cobra.Command), configFieldMap map[string]string, requiredCreateFlags []string) *cobra.Command {
-	return userGroupWithConfig(app, use, short, userAPIPath, configAPIPath, configAPIPath, addFlags, fieldMap, configAddFlags, configFieldMap, requiredCreateFlags)
+func serviceGroup(app *cliapp.Runtime, use, short, configAPIPath, userAPIPath string, addFlags func(*cobra.Command), fieldMap map[string]string, configAddFlags func(*cobra.Command), configFieldMap map[string]string, createDefaults map[string]interface{}, requiredCreateFlags []string, defaultColumns []string) *cobra.Command {
+	return userGroupWithConfig(app, use, short, userAPIPath, configAPIPath, configAPIPath, addFlags, fieldMap, configAddFlags, configFieldMap, createDefaults, requiredCreateFlags, defaultColumns)
 }
 
 func snmpdGroup(app *cliapp.Runtime) *cobra.Command {
@@ -227,6 +274,7 @@ func snmpdGroup(app *cliapp.Runtime) *cobra.Command {
 				if err := app.RequireAuth(); err != nil {
 					return err
 				}
+				app.DefaultColumns = []string{"id", "enabled", "listen_port", "version", "community", "rw"}
 				raw, err := app.APIClient.Get(cliapp.APIBase+"/advanced-service/snmpd-config", nil)
 				if err != nil {
 					return err
@@ -235,30 +283,11 @@ func snmpdGroup(app *cliapp.Runtime) *cobra.Command {
 				return nil
 			},
 		},
-		dataCmd(app, "set", "Update SNMPD configuration", addSNMPDFlags, snmpdFieldMap, func(body interface{}, id string) (json.RawMessage, error) {
+		dataCmd(app, "set", "Update SNMPD configuration", addSNMPDFlags, snmpdFieldMap, nil, func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Put(cliapp.APIBase+"/advanced-service/snmpd-config", body)
 		}),
 	)
 	return group
-}
-
-func getByIDCmd(app *cliapp.Runtime, use, short, apiPath string) *cobra.Command {
-	return &cobra.Command{
-		Use:   use,
-		Short: short,
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := app.RequireAuth(); err != nil {
-				return err
-			}
-			raw, err := app.APIClient.Get(cliapp.APIBase+apiPath+args[0], nil)
-			if err != nil {
-				return err
-			}
-			app.PrintRaw(raw)
-			return nil
-		},
-	}
 }
 
 func deleteByIDCmd(app *cliapp.Runtime, use, short, apiPath string) *cobra.Command {
@@ -292,15 +321,15 @@ func deleteByIDCmd(app *cliapp.Runtime, use, short, apiPath string) *cobra.Comma
 
 type callWithBody func(body interface{}, id string) (json.RawMessage, error)
 
-func dataCmd(app *cliapp.Runtime, use, short string, addFlags func(*cobra.Command), fieldMap map[string]string, fn callWithBody) *cobra.Command {
-	return dataCmdImpl(app, use, short, false, addFlags, fieldMap, fn)
+func dataCmd(app *cliapp.Runtime, use, short string, addFlags func(*cobra.Command), fieldMap map[string]string, defaults map[string]interface{}, fn callWithBody) *cobra.Command {
+	return dataCmdImpl(app, use, short, false, addFlags, fieldMap, defaults, fn)
 }
 
 func dataCmdWithID(app *cliapp.Runtime, use, short string, addFlags func(*cobra.Command), fieldMap map[string]string, fn callWithBody) *cobra.Command {
-	return dataCmdImpl(app, use, short, true, addFlags, fieldMap, fn)
+	return dataCmdImpl(app, use, short, true, addFlags, fieldMap, nil, fn)
 }
 
-func dataCmdImpl(app *cliapp.Runtime, use, short string, withID bool, addFlags func(*cobra.Command), fieldMap map[string]string, fn callWithBody) *cobra.Command {
+func dataCmdImpl(app *cliapp.Runtime, use, short string, withID bool, addFlags func(*cobra.Command), fieldMap map[string]string, defaults map[string]interface{}, fn callWithBody) *cobra.Command {
 	c := &cobra.Command{Use: use, Short: short}
 	if use == "create" {
 		c.Aliases = []string{"new"}
@@ -321,6 +350,11 @@ func dataCmdImpl(app *cliapp.Runtime, use, short string, withID bool, addFlags f
 		body, err := cliapp.MergeDataWithFlags(data, cmd, fieldMap)
 		if err != nil {
 			return err
+		}
+		for k, v := range defaults {
+			if _, exists := body[k]; !exists {
+				body[k] = v
+			}
 		}
 		id := ""
 		if withID {

--- a/internal/cmd/network/command.go
+++ b/internal/cmd/network/command.go
@@ -175,6 +175,7 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		"enabled":    "enabled",
 	}
 	dnsProxyCreateDefaults := map[string]interface{}{
+		"enabled":  "yes",
 		"is_ipv6":  0,
 		"comment":  "",
 		"src_addr": "",
@@ -303,6 +304,13 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			for k, v := range map[string]interface{}{
+				"enabled": "yes", "delay": 0, "check_addr_valid": 0, "check_relay_only": 0,
+			} {
+				if _, exists := body[k]; !exists {
+					body[k] = v
+				}
+			}
 			raw, err := app.APIClient.Post(cliapp.APIBase+"/network/dhcp/services", body)
 			if err != nil {
 				return err
@@ -429,6 +437,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			body, err := cliapp.MergeDataWithFlags(data, cmd, dhcpStaticFieldMap)
 			if err != nil {
 				return err
+			}
+			if _, exists := body["enabled"]; !exists {
+				body["enabled"] = "yes"
 			}
 			raw, err := app.APIClient.Post(cliapp.APIBase+"/network/dhcp/static", body)
 			if err != nil {
@@ -570,6 +581,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			body, err := cliapp.MergeDataWithFlags(data, cmd, dhcpAccessRuleFieldMap)
 			if err != nil {
 				return err
+			}
+			if _, exists := body["enabled"]; !exists {
+				body["enabled"] = "yes"
 			}
 			raw, err := app.APIClient.Post(cliapp.APIBase+"/network/dhcp/access-control/rules", body)
 			if err != nil {
@@ -829,6 +843,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			body, err := cliapp.MergeDataWithFlags(data, cmd, vlanFieldMap)
 			if err != nil {
 				return err
+			}
+			if _, exists := body["enabled"]; !exists {
+				body["enabled"] = "yes"
 			}
 			raw, err := app.APIClient.Post(cliapp.APIBase+"/network/vlan", body)
 			if err != nil {

--- a/internal/cmd/qos/command.go
+++ b/internal/cmd/qos/command.go
@@ -24,6 +24,7 @@ var qosIPAddrFields = map[string]string{
 	"dst-port": "dst_port",
 }
 var qosIPCreateDefaults = map[string]interface{}{
+	"enabled":  "yes",
 	"comment":  "",
 	"type":     0,
 	"protocol": "any",
@@ -54,6 +55,7 @@ var qosMACAddrFields = map[string]string{
 	"mac-addr": "mac_addr",
 }
 var qosMACCreateDefaults = map[string]interface{}{
+	"enabled": "yes",
 	"comment": "",
 	"time": map[string]interface{}{
 		"custom": []interface{}{

--- a/internal/cmd/routing/command.go
+++ b/internal/cmd/routing/command.go
@@ -84,10 +84,10 @@ var (
 		"src-addr":  "src_addr",
 	}
 	l7Defaults = map[string]interface{}{
-		"enabled":   "yes",
-		"comment":   "",
-		"app_proto": map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
-		"mode":      0,
+		"enabled":    "yes",
+		"comment":    "",
+		"app_proto":  map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
+		"mode":       0,
 		"prio":       31,
 		"iface_band": 0,
 		"src_addr":   map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},

--- a/internal/cmd/routing/command.go
+++ b/internal/cmd/routing/command.go
@@ -23,8 +23,10 @@ var (
 		"src-addr": "src_addr",
 	}
 	domainDefaults = map[string]interface{}{
+		"enabled":  "yes",
 		"comment":  "",
 		"prio":     31,
+		"domain":   map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
 		"src_addr": map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
 		"time": map[string]interface{}{
 			"custom": []interface{}{
@@ -49,6 +51,7 @@ var (
 		"dst-port": "dst_port",
 	}
 	fiveTupleDefaults = map[string]interface{}{
+		"enabled":      "yes",
 		"comment":      "",
 		"type":         0,
 		"mode":         0,
@@ -81,8 +84,10 @@ var (
 		"src-addr":  "src_addr",
 	}
 	l7Defaults = map[string]interface{}{
-		"comment":    "",
-		"mode":       0,
+		"enabled":   "yes",
+		"comment":   "",
+		"app_proto": map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
+		"mode":      0,
 		"prio":       31,
 		"iface_band": 0,
 		"src_addr":   map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
@@ -103,6 +108,7 @@ var (
 		"enabled":   "enabled",
 	}
 	loadBalanceDefaults = map[string]interface{}{
+		"enabled":  "yes",
 		"comment":  "",
 		"mode":     0,
 		"weight":   "1",
@@ -124,6 +130,7 @@ var (
 		"dst-port": "dst_port",
 	}
 	updownDefaults = map[string]interface{}{
+		"enabled":  "yes",
 		"comment":  "",
 		"protocol": "any",
 		"src_addr": map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
@@ -197,6 +204,7 @@ func staticGroup(app *cliapp.Runtime) *cobra.Command {
 		"enabled":   "enabled",
 	}
 	staticDefaults := map[string]interface{}{
+		"enabled": "yes",
 		"ip_type": "4",
 		"comment": "",
 		"prio":    1,

--- a/internal/cmd/security/command.go
+++ b/internal/cmd/security/command.go
@@ -24,6 +24,7 @@ var (
 	// aclCreateDefaults provides required fields the iKuai API expects
 	// but are not exposed as flags (sensible defaults for most use cases).
 	aclCreateDefaults = map[string]interface{}{
+		"enabled":       "yes",
 		"ip_type":       "4",
 		"ctdir":         0,
 		"dir":           "forward",
@@ -76,9 +77,11 @@ var (
 		"enabled":  "enabled",
 	}
 	l7CreateDefaults = map[string]interface{}{
-		"comment":  "",
-		"src_addr": "",
-		"dst_addr": "",
+		"enabled":   "yes",
+		"comment":   "",
+		"app_proto": map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
+		"src_addr":  "",
+		"dst_addr":  "",
 		"time": map[string]interface{}{
 			"custom": []interface{}{
 				map[string]interface{}{
@@ -102,6 +105,7 @@ var (
 		"enabled": "enabled",
 	}
 	macCreateDefaults = map[string]interface{}{
+		"enabled": "yes",
 		"expires": 0,
 		"comment": "",
 		"time": map[string]interface{}{
@@ -131,6 +135,7 @@ var (
 		"enabled":  "enabled",
 	}
 	peerconnCreateDefaults = map[string]interface{}{
+		"enabled":  "yes",
 		"comment":  "",
 		"src_addr": map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
 		"dst_port": map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
@@ -183,7 +188,9 @@ var (
 		"enabled": "enabled",
 	}
 	urlBlackCreateDefaults = map[string]interface{}{
-		"comment":  "",
+		"enabled": "yes",
+		"domain":  map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
+		"comment": "",
 		"src_addr": map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
 		"time":     map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
 	}
@@ -192,6 +199,19 @@ var (
 	urlBlackAddrFields = map[string]string{
 		"domain":   "domain",
 		"src-addr": "src_addr",
+	}
+
+	domainBlacklistCreateDefaults = map[string]interface{}{
+		"enabled": "yes",
+	}
+	urlKeywordsCreateDefaults = map[string]interface{}{
+		"enabled": "yes",
+	}
+	urlRedirectCreateDefaults = map[string]interface{}{
+		"enabled": "yes",
+	}
+	urlReplaceCreateDefaults = map[string]interface{}{
+		"enabled": "yes",
 	}
 
 	// mac set-mode: acl_mac (0=blacklist, 1=whitelist)
@@ -277,14 +297,17 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			requiredCreateFlags: []string{"name", "mode"},
 		}),
 		secGroup(app, "keywords", "URL keyword rules", "security/url-keywords/rules", false, urlKeywordsFieldMap, secGroupOpts{
+			createDefaults:      urlKeywordsCreateDefaults,
 			defaultColumns:      []string{"id", "tagname", "mode", "src_url", "ori_keyword", "rep_keyword", "hit_rate", "prio", "enabled"},
 			requiredCreateFlags: []string{"name", "mode", "src-url", "ori-keyword", "rep-keyword", "hit-rate", "priority"},
 		}),
 		secGroup(app, "redirect", "URL redirect rules", "security/url-redirect/rules", false, urlRedirectFieldMap, secGroupOpts{
+			createDefaults:      urlRedirectCreateDefaults,
 			defaultColumns:      []string{"id", "tagname", "mode", "src_url", "dst_url", "hit_rate", "prio", "enabled"},
 			requiredCreateFlags: []string{"name", "mode", "src-url", "dst-url", "hit-rate", "priority"},
 		}),
 		secGroup(app, "replace", "URL replace rules", "security/url-replace/rules", false, urlReplaceFieldMap, secGroupOpts{
+			createDefaults:      urlReplaceCreateDefaults,
 			defaultColumns:      []string{"id", "tagname", "mode", "src_url", "param_keyword", "rep_keyword", "hit_rate", "prio", "enabled"},
 			requiredCreateFlags: []string{"name", "mode", "src-url", "param-keyword", "rep-keyword", "hit-rate", "priority"},
 		}),
@@ -292,6 +315,7 @@ func New(app *cliapp.Runtime) *cobra.Command {
 	securityCmd.AddCommand(urlCmd)
 
 	securityCmd.AddCommand(secGroup(app, "domain-blacklist", "Domain blacklist rules", "security/domain-blacklist/rules", false, domainBlacklistFieldMap, secGroupOpts{
+		createDefaults:      domainBlacklistCreateDefaults,
 		requiredCreateFlags: []string{"name", "domain-group"},
 	}))
 	securityCmd.AddCommand(secGroup(app, "peerconn", "Peer connection rules", "security/peerconn/rules", false, peerconnFieldMap, secGroupOpts{

--- a/internal/cmd/security/command.go
+++ b/internal/cmd/security/command.go
@@ -188,9 +188,9 @@ var (
 		"enabled": "enabled",
 	}
 	urlBlackCreateDefaults = map[string]interface{}{
-		"enabled": "yes",
-		"domain":  map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
-		"comment": "",
+		"enabled":  "yes",
+		"domain":   map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
+		"comment":  "",
 		"src_addr": map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
 		"time":     map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
 	}

--- a/internal/cmd/system/command.go
+++ b/internal/cmd/system/command.go
@@ -110,6 +110,7 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		"enabled":    "enabled",
 	}
 	schedulesDefaults := map[string]interface{}{
+		"enabled": "yes",
 		"event":   "reboot",
 		"comment": "",
 	}

--- a/internal/cmd/users/command.go
+++ b/internal/cmd/users/command.go
@@ -20,6 +20,7 @@ var (
 		"enabled":  "enabled",
 	}
 	accountDefaults = map[string]interface{}{
+		"enabled":     "yes",
 		"comment":     "",
 		"ppptype":     "any",
 		"packages":    0,

--- a/internal/cmd/vpn/command.go
+++ b/internal/cmd/vpn/command.go
@@ -21,6 +21,7 @@ var (
 		"enabled":   "enabled",
 	}
 	pptpClientDefaults = map[string]interface{}{
+		"enabled":           "yes",
 		"comment":           "",
 		"server_port":       1723,
 		"mtu":               1400,
@@ -43,6 +44,7 @@ var (
 		"enabled":   "enabled",
 	}
 	l2tpClientDefaults = map[string]interface{}{
+		"enabled":           "yes",
 		"comment":           "",
 		"server_port":       1701,
 		"mtu":               1400,
@@ -67,6 +69,7 @@ var (
 		"enabled":     "enabled",
 	}
 	openvpnClientDefaults = map[string]interface{}{
+		"enabled":           "yes",
 		"comment":           "",
 		"remote_port":       "1194",
 		"method":            0,
@@ -97,6 +100,7 @@ var (
 		"enabled":     "enabled",
 	}
 	ikev2ClientDefaults = map[string]interface{}{
+		"enabled":         "yes",
 		"comment":         "",
 		"authby":          "mschapv2",
 		"check_link_mode": 3,
@@ -115,6 +119,7 @@ var (
 		"enabled":      "enabled",
 	}
 	ipsecClientDefaults = map[string]interface{}{
+		"enabled":     "yes",
 		"comment":     "",
 		"keyexchange": "ikev2",
 		"authby":      "secret",
@@ -140,6 +145,7 @@ var (
 		"enabled":   "enabled",
 	}
 	wireguardDefaults = map[string]interface{}{
+		"enabled":          "yes",
 		"interface":        "auto",
 		"local_listenport": 5000,
 		"mtu":              1420,
@@ -157,6 +163,7 @@ var (
 		"enabled":    "enabled",
 	}
 	wireguardPeerDefaults = map[string]interface{}{
+		"enabled":   "yes",
 		"comment":   "",
 		"keepalive": 0,
 	}
@@ -411,12 +418,19 @@ func wireguardGroup(app *cliapp.Runtime) *cobra.Command {
 	wgCreateFieldMap["private-key"] = "local_privatekey"
 	wgCreateFieldMap["public-key"] = "local_publickey"
 
-	// WireGuard tunnel create has no RequireFlags here — local_privatekey/local_publickey
-	// are B2-class missing fields tracked separately, not in this validation pass.
 	wgCreateCmd := writeCmd(app, "create", "Create a WireGuard tunnel", false, wgCreateFieldMap, nil, wireguardDefaults,
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/vpn/wireguard", body)
 		})
+	{
+		origRunE := wgCreateCmd.RunE
+		wgCreateCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := cliapp.RequireFlags(cmd, "name", "address", "private-key", "public-key"); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
 	peerCreateCmd := writeCmd(app, "peer-create ID", "Create a peer on a WireGuard tunnel", true, wireguardPeerFieldMap, nil, wireguardPeerDefaults,
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/vpn/wireguard/"+id+"/peers", body)

--- a/internal/cmd/wireless/command.go
+++ b/internal/cmd/wireless/command.go
@@ -25,7 +25,9 @@ var (
 		"mac": "lmac",
 	}
 	blacklistDefaults = map[string]interface{}{
+		"enabled": "yes",
 		"mode":    0,
+		"lmac":    map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
 		"lssid":   "ALL",
 		"lap":     "ALL",
 		"week":    "1234567",
@@ -44,7 +46,9 @@ var (
 		"mac": "lmac",
 	}
 	vlanDefaults = map[string]interface{}{
+		"enabled": "yes",
 		"lssid":   "ALL",
+		"lmac":    map[string]interface{}{"custom": []interface{}{}, "object": []interface{}{}},
 		"comment": "",
 	}
 )

--- a/skills/advanced.md
+++ b/skills/advanced.md
@@ -11,7 +11,7 @@ description: iKuai advanced services — FTP, HTTP, Samba file servers and SNMPD
 ikuai-cli advanced ftp config-get
 ikuai-cli advanced ftp config-set --open-ftp 1 --ftp-port 21 --ftp-access 1
 ikuai-cli advanced ftp list
-ikuai-cli advanced ftp create --name "ftpuser" --username "user1" --password "123456" --permission rw --home-dir "/sda1" --enabled yes
+ikuai-cli advanced ftp create --username "user1" --password "123456" --permission rw --home-dir "/test001"
 ikuai-cli advanced ftp toggle <ID> --enabled no
 ikuai-cli advanced ftp delete <ID>
 ```
@@ -22,7 +22,9 @@ FTP/HTTP/Samba 用户 CRUD 需路由器挂载外接存储。
 
 ```bash
 ikuai-cli advanced http list
-ikuai-cli advanced http create --name "www" --port "8080" --home-dir "/sda1" --enabled yes
+ikuai-cli advanced http create --name "www" --port 8080 --ssl 0 --autoindex 0 --download 0 --home-dir "/test001"
+ikuai-cli advanced http toggle <ID> --enabled no
+ikuai-cli advanced http delete <ID>
 ```
 
 ## Samba
@@ -31,14 +33,17 @@ ikuai-cli advanced http create --name "www" --port "8080" --home-dir "/sda1" --e
 ikuai-cli advanced samba config-get
 ikuai-cli advanced samba config-set --enabled yes --workgroup WORKGROUP --wsdd2 1 --access 1
 ikuai-cli advanced samba list
-ikuai-cli advanced samba create --name "share1" --username "user1" --password "123456" --permission rw --enabled yes
+ikuai-cli advanced samba create --name "share1" --username "user1" --password "123456" --permission rw --guest yes --home-dir "/test001"
+ikuai-cli advanced samba toggle <ID> --enabled no
+ikuai-cli advanced samba delete <ID>
 ```
 
 ## SNMPD
 
 ```bash
 ikuai-cli advanced snmpd get
-ikuai-cli advanced snmpd set --enabled yes --listen-port 161 --version 2 --community public
+ikuai-cli advanced snmpd get --wide
+ikuai-cli advanced snmpd set --enabled yes --listen-port 161 --version 2 --community public --rw ro
 ```
 
-SNMPD set 是全量更新，需传所有 required 字段。
+SNMPD set 是全量更新，需传所有 required 字段（15个）。

--- a/skills/network.md
+++ b/skills/network.md
@@ -14,7 +14,7 @@ ikuai-cli network dns stats
 
 # DNS 代理
 ikuai-cli network dns proxy list
-ikuai-cli network dns proxy create --domain "example.com" --dns-addr "8.8.8.8" --parse-type 0 --enabled yes
+ikuai-cli network dns proxy create --domain "example.com" --dns-addr "8.8.8.8" --parse-type 0
 ikuai-cli network dns proxy delete <ID>
 ```
 
@@ -23,7 +23,7 @@ ikuai-cli network dns proxy delete <ID>
 ```bash
 ikuai-cli network dhcp list
 ikuai-cli network dhcp get <ID>
-ikuai-cli network dhcp create --name "Office" --interface lan1 --addr-pool "192.168.1.100-200" --gateway "192.168.1.1" --netmask "255.255.255.0" --dns1 "223.5.5.5" --enabled yes
+ikuai-cli network dhcp create --name "Office" --interface lan1 --addr-pool "192.168.1.100-200" --gateway "192.168.1.1" --netmask "255.255.255.0" --dns1 "223.5.5.5"
 ikuai-cli network dhcp toggle <ID> --enabled no
 ikuai-cli network dhcp delete <ID>
 ikuai-cli network dhcp clients
@@ -31,7 +31,7 @@ ikuai-cli network dhcp restart / start / stop
 
 # 静态绑定
 ikuai-cli network dhcp static list
-ikuai-cli network dhcp static create --name "Printer" --ip-addr "192.168.1.50" --mac "AA:BB:CC:DD:EE:FF" --interface lan1 --enabled yes
+ikuai-cli network dhcp static create --name "Printer" --ip-addr "192.168.1.50" --mac "AA:BB:CC:DD:EE:FF" --interface lan1
 ikuai-cli network dhcp static toggle <ID> --enabled no
 ikuai-cli network dhcp static delete <ID>
 
@@ -55,7 +55,7 @@ ikuai-cli network physical
 
 ```bash
 ikuai-cli network vlan list
-ikuai-cli network vlan create --name "IoT" --vlan-id 100 --interface lan1 --ip-addr "10.0.100.1" --netmask "255.255.255.0" --enabled yes
+ikuai-cli network vlan create --name "IoT" --vlan-id 100 --interface lan1 --ip-addr "10.0.100.1" --netmask "255.255.255.0"
 ikuai-cli network vlan toggle <ID> --enabled no
 ikuai-cli network vlan delete <ID>
 ```
@@ -64,7 +64,7 @@ ikuai-cli network vlan delete <ID>
 
 ```bash
 ikuai-cli network nat list
-ikuai-cli network nat create --name "forward_web" --action DNAT --in-interface wan1 --out-interface lan1 --src-addr "any" --dst-addr "192.168.1.10" --protocol tcp --enabled yes
+ikuai-cli network nat create --name "forward_web" --action DNAT --in-interface wan1 --out-interface lan1 --src-addr "any" --dst-addr "192.168.1.10" --protocol tcp
 ikuai-cli network nat toggle <ID> --enabled no
 ikuai-cli network nat delete <ID>
 

--- a/skills/qos.md
+++ b/skills/qos.md
@@ -9,7 +9,7 @@ description: iKuai QoS bandwidth control — IP-based and MAC-based bandwidth li
 
 ```bash
 ikuai-cli qos ip list
-ikuai-cli qos ip create --name "limit_100m" --ip-addr "192.168.9.0/24" --upload 100 --download 100 --interface wan1 --enabled yes
+ikuai-cli qos ip create --name "limit_100m" --ip-addr "192.168.9.0/24" --upload 100 --download 100 --interface wan1
 ikuai-cli qos ip get <ID>
 ikuai-cli qos ip toggle <ID> --enabled no
 ikuai-cli qos ip delete <ID>
@@ -21,7 +21,7 @@ ikuai-cli qos ip delete <ID>
 
 ```bash
 ikuai-cli qos mac list
-ikuai-cli qos mac create --name "limit_mac" --mac-addr "00:11:22:33:44:55" --upload 50 --download 50 --interface wan1 --enabled yes
+ikuai-cli qos mac create --name "limit_mac" --mac-addr "00:11:22:33:44:55" --upload 50 --download 50 --interface wan1
 ikuai-cli qos mac toggle <ID> --enabled no
 ikuai-cli qos mac delete <ID>
 ```

--- a/skills/routing.md
+++ b/skills/routing.md
@@ -9,7 +9,7 @@ description: iKuai routing — static routes, traffic shunting (domain, five-tup
 
 ```bash
 ikuai-cli routing static list
-ikuai-cli routing static create --name "to_lan2" --dst-addr "10.10.10.0" --gateway "10.66.0.1" --netmask "255.255.255.0" --interface wan1 --enabled yes
+ikuai-cli routing static create --name "to_lan2" --dst-addr "10.10.10.0" --gateway "10.66.0.1" --netmask "255.255.255.0" --interface wan1
 ikuai-cli routing static toggle <ID> --enabled no
 ikuai-cli routing static delete <ID>
 ```
@@ -21,7 +21,7 @@ ikuai-cli routing static delete <ID>
 ### 域名分流
 ```bash
 ikuai-cli routing stream domain list
-ikuai-cli routing stream domain create --name "baidu" --domain "www.baidu.com,baidu.com" --interface wan2 --enabled yes
+ikuai-cli routing stream domain create --name "baidu" --domain "www.baidu.com,baidu.com" --interface wan2
 ikuai-cli routing stream domain toggle <ID> --enabled no
 ikuai-cli routing stream domain delete <ID>
 ```
@@ -29,25 +29,25 @@ ikuai-cli routing stream domain delete <ID>
 ### 五元组分流
 ```bash
 ikuai-cli routing stream five-tuple list
-ikuai-cli routing stream five-tuple create --name "web_wan2" --protocol tcp --dst-port "80,443" --interface wan2 --enabled yes
+ikuai-cli routing stream five-tuple create --name "web_wan2" --protocol tcp --dst-port "80,443" --interface wan2
 ```
 
 ### L7 协议分流
 ```bash
 ikuai-cli routing stream l7 list
-ikuai-cli routing stream l7 create --name "dns_wan2" --app-proto "DNS" --interface wan2 --enabled yes
+ikuai-cli routing stream l7 create --name "dns_wan2" --app-proto "DNS" --interface wan2
 ```
 
 ### 负载均衡
 ```bash
 ikuai-cli routing stream load-balance list
-ikuai-cli routing stream load-balance create --name "lb_wan1" --interface wan1 --enabled yes
+ikuai-cli routing stream load-balance create --name "lb_wan1" --interface wan1
 ```
 
 ### 上下行分离
 ```bash
 ikuai-cli routing stream updown list
-ikuai-cli routing stream updown create --name "split" --upiface wan1 --downiface wan2 --enabled yes
+ikuai-cli routing stream updown create --name "split" --upiface wan1 --downiface wan2
 ```
 
 所有 stream 子命令支持 `--src-addr`、`--dst-addr` 等 addrFields。

--- a/skills/security.md
+++ b/skills/security.md
@@ -10,7 +10,7 @@ description: iKuai security rules — ACL, MAC filtering, L7 app rules, URL filt
 ```bash
 ikuai-cli security acl list
 ikuai-cli security acl get <ID>
-ikuai-cli security acl create --name "block_ssh" --action drop --protocol tcp --dst-port "22" --enabled yes
+ikuai-cli security acl create --name "block_ssh" --action drop --protocol tcp --dst-port "22"
 ikuai-cli security acl toggle <ID> --enabled no
 ikuai-cli security acl delete <ID>
 ```
@@ -24,7 +24,7 @@ ikuai-cli security mac get-mode
 ikuai-cli security mac set-mode --acl-mac 0
 # --data '{"acl_mac":0}' 也可用
 ikuai-cli security mac list
-ikuai-cli security mac create --name "allow1" --mac "00:11:22:33:44:55" --enabled yes
+ikuai-cli security mac create --name "allow1" --mac "00:11:22:33:44:55"
 ikuai-cli security mac toggle <ID> --enabled no
 ikuai-cli security mac delete <ID>
 ```
@@ -34,7 +34,7 @@ ikuai-cli security mac delete <ID>
 ```bash
 ikuai-cli security l7 list
 ikuai-cli security l7 get <ID>
-ikuai-cli security l7 create --name "block_p2p" --action drop --app-proto "BT,eMule" --enabled yes
+ikuai-cli security l7 create --name "block_p2p" --action drop --app-proto "BT,eMule"
 ikuai-cli security l7 toggle <ID> --enabled no
 ikuai-cli security l7 delete <ID>
 ```
@@ -44,27 +44,27 @@ ikuai-cli security l7 delete <ID>
 ```bash
 # 黑名单
 ikuai-cli security url black list
-ikuai-cli security url black create --name "block_ads" --mode 0 --domain "ads.example.com" --enabled yes
+ikuai-cli security url black create --name "block_ads" --mode 0 --domain "ads.example.com"
 ikuai-cli security url black delete <ID>
 
 # 关键词
 ikuai-cli security url keywords list
-ikuai-cli security url keywords create --name "kw1" --mode exact --src-url "example.com" --ori-keyword "bad" --rep-keyword "good" --enabled yes
+ikuai-cli security url keywords create --name "kw1" --mode exact --src-url "example.com" --ori-keyword "bad" --rep-keyword "good"
 
 # 重定向
 ikuai-cli security url redirect list
-ikuai-cli security url redirect create --name "redir1" --mode exact --src-url "old.com" --dst-url "new.com" --enabled yes
+ikuai-cli security url redirect create --name "redir1" --mode exact --src-url "old.com" --dst-url "new.com"
 
 # 替换
 ikuai-cli security url replace list
-ikuai-cli security url replace create --name "rep1" --mode exact --src-url "example.com" --param-keyword "track" --rep-keyword "" --enabled yes
+ikuai-cli security url replace create --name "rep1" --mode exact --src-url "example.com" --param-keyword "track" --rep-keyword ""
 ```
 
 ## 域名黑名单
 
 ```bash
 ikuai-cli security domain-blacklist list
-ikuai-cli security domain-blacklist create --name "blocked" --domain-group "evil.com" --enabled yes
+ikuai-cli security domain-blacklist create --name "blocked" --domain-group "evil.com"
 ikuai-cli security domain-blacklist delete <ID>
 ```
 
@@ -72,7 +72,7 @@ ikuai-cli security domain-blacklist delete <ID>
 
 ```bash
 ikuai-cli security peerconn list
-ikuai-cli security peerconn create --name "limit1" --limits 500 --protocol tcp --src-addr "192.168.9.0/24" --enabled yes
+ikuai-cli security peerconn create --name "limit1" --limits 500 --protocol tcp --src-addr "192.168.9.0/24"
 ```
 
 ## 终端标注（Terminals）

--- a/skills/system.md
+++ b/skills/system.md
@@ -17,7 +17,7 @@ ikuai-cli system ntp-sync
 
 ```bash
 ikuai-cli system schedules list
-ikuai-cli system schedules create --name "weekly_reboot" --strategy week --cycle-time "7" --time "03:00" --enabled yes
+ikuai-cli system schedules create --name "weekly_reboot" --strategy week --cycle-time "7" --time "03:00"
 # defaults: event=reboot
 ikuai-cli system schedules toggle <ID> --enabled no
 ikuai-cli system schedules delete <ID>

--- a/skills/users.md
+++ b/skills/users.md
@@ -17,7 +17,7 @@ ikuai-cli users kick <SESSION_ID>
 ```bash
 ikuai-cli users accounts list
 ikuai-cli users accounts get <ID>
-ikuai-cli users accounts create --username "guest1" --password "123456" --enabled yes
+ikuai-cli users accounts create --username "guest1" --password "123456"
 # defaults: ppptype=any, upload=0, download=0, share=1, expires=0
 ikuai-cli users accounts delete <ID>
 ```

--- a/skills/vpn.md
+++ b/skills/vpn.md
@@ -15,7 +15,7 @@ ikuai-cli vpn pptp set --enabled yes --server-ip "10.0.0.1" --server-port 1723 -
 
 # 客户端 CRUD
 ikuai-cli vpn pptp clients
-ikuai-cli vpn pptp client-create --name pptp_office --server "vpn.example.com" --username user1 --password "123456" --interface auto --enabled yes
+ikuai-cli vpn pptp client-create --name pptp_office --server "vpn.example.com" --username user1 --password "123456" --interface auto
 ikuai-cli vpn pptp client-update <ID> --server "vpn2.example.com"
 ikuai-cli vpn pptp kick <ID>
 ```
@@ -30,7 +30,7 @@ OpenVPN/IKEv2 server set 字段多（含证书），建议用 `--data` 全量传
 ```bash
 ikuai-cli vpn openvpn get
 ikuai-cli vpn openvpn clients
-ikuai-cli vpn openvpn client-create --name ovpn_office --remote-addr "vpn.example.com" --username user1 --password "123456" --ca "<CA证书>" --interface auto --enabled yes
+ikuai-cli vpn openvpn client-create --name ovpn_office --remote-addr "vpn.example.com" --username user1 --password "123456" --ca "<CA证书>" --interface auto
 ikuai-cli vpn openvpn kick <ID>
 ```
 
@@ -41,7 +41,7 @@ ikuai-cli vpn openvpn kick <ID>
 ```bash
 ikuai-cli vpn ikev2 get
 ikuai-cli vpn ikev2 clients
-ikuai-cli vpn ikev2 client-create --name iked_office --remote-addr "vpn.example.com" --interface auto --left-id "localid" --username user1 --password "123456" --enabled yes
+ikuai-cli vpn ikev2 client-create --name iked_office --remote-addr "vpn.example.com" --interface auto --left-id "localid" --username user1 --password "123456"
 ikuai-cli vpn ikev2 kick <ID>
 ```
 
@@ -51,7 +51,7 @@ name 需以 `iked` 开头，authby=mschapv2 时 username 必填。
 
 ```bash
 ikuai-cli vpn ipsec clients
-ikuai-cli vpn ipsec client-create --name ipsec_site --remote-addr "10.0.0.1" --interface wan1 --left-subnet "192.168.1.0/24" --right-subnet "192.168.2.0/24" --secret "psk123" --enabled yes
+ikuai-cli vpn ipsec client-create --name ipsec_site --remote-addr "10.0.0.1" --interface wan1 --left-subnet "192.168.1.0/24" --right-subnet "192.168.2.0/24" --secret "psk123"
 # defaults: keyexchange=ikev2, authby=secret, dpdaction=none, ikelifetime=3, lifetime=1
 ikuai-cli vpn ipsec kick <ID>
 ```
@@ -61,7 +61,7 @@ ikuai-cli vpn ipsec kick <ID>
 ```bash
 # 隧道
 ikuai-cli vpn wireguard list
-ikuai-cli vpn wireguard create --name wg_site --address "10.9.0.1/24" --private-key "<base64>" --public-key "<base64>" --enabled yes
+ikuai-cli vpn wireguard create --name wg_site --address "10.9.0.1/24" --private-key "<base64>" --public-key "<base64>"
 # defaults: interface=auto, port=5000, mtu=1420
 ikuai-cli vpn wireguard get <ID>
 ikuai-cli vpn wireguard toggle <ID> --enabled no
@@ -69,6 +69,6 @@ ikuai-cli vpn wireguard delete <ID>
 
 # 对端
 ikuai-cli vpn wireguard peers <TUNNEL_ID>
-ikuai-cli vpn wireguard peer-create <TUNNEL_ID> --public-key "<base64>" --allow-ips "10.9.0.2/32" --interface wg0 --enabled yes
+ikuai-cli vpn wireguard peer-create <TUNNEL_ID> --public-key "<base64>" --allow-ips "10.9.0.2/32" --interface wg0
 ikuai-cli vpn wireguard peer-delete <TUNNEL_ID> <PEER_ID>
 ```

--- a/skills/wireless.md
+++ b/skills/wireless.md
@@ -9,7 +9,7 @@ description: iKuai wireless — blacklist/whitelist rules, VLAN rules, AC manage
 
 ```bash
 ikuai-cli wireless blacklist list
-ikuai-cli wireless blacklist create --name "block1" --mac "00:11:22:33:44:55" --enabled yes
+ikuai-cli wireless blacklist create --name "block1" --mac "00:11:22:33:44:55"
 # defaults: mode=0(黑名单), lssid=ALL, lap=ALL, week=1234567, time=00:00-23:59
 ikuai-cli wireless blacklist toggle <ID> --enabled no
 ikuai-cli wireless blacklist delete <ID>
@@ -19,7 +19,7 @@ ikuai-cli wireless blacklist delete <ID>
 
 ```bash
 ikuai-cli wireless vlan list
-ikuai-cli wireless vlan create --name "iot_vlan" --vlan-id 100 --mac "00:11:22:33:44:55" --enabled yes
+ikuai-cli wireless vlan create --name "iot_vlan" --vlan-id 100 --mac "00:11:22:33:44:55"
 ikuai-cli wireless vlan toggle <ID> --enabled no
 ikuai-cli wireless vlan delete <ID>
 ```


### PR DESCRIPTION
## Summary

- 为所有 create/toggle 命令添加客户端 RequireFlags 校验，缺少必填参数时提示具体字段名
- 为所有 create 命令补齐 createDefaults（enabled="yes" 等），用户不再需要手动传可预设的 YAML required 字段
- WireGuard create 补充 RequireFlags（name/address/private-key/public-key）
- advanced 模块 dataCmdImpl 改造支持 defaults 参数传递
- 同步更新 docs/cli-reference.md 和 skills 文档，移除示例中多余的 --enabled yes

## Changes

### 客户端校验（commit 1）
- 新增 cliapp.RequireFlags() 工具函数 + 单测
- 所有 create 命令添加用户必填 flag 校验（对照参数清单）
- 所有 toggle 命令强制 --enabled 参数
- root.go PersistentPreRunE 重置 DefaultColumns/UserColumns 防 REPL 泄漏

### createDefaults 补齐（commit 2）
- routing: 6 个 stream defaults 补 enabled/domain/app_proto
- network: DHCP/static/access-rule/VLAN 补 enabled + DHCP 额外字段
- security: 9 个 defaults 补 enabled + 新建 4 个 URL/domain defaults
- vpn: 7 个 client defaults 补 enabled
- users/qos/system/wireless: 补 enabled
- advanced: dataCmdImpl 支持 defaults + ftp/http/samba defaults + defaultColumns