### PR TITLE
docs: improve help descriptions and mark required flags for all commands

### DIFF
--- a/internal/cliapp/helpers.go
+++ b/internal/cliapp/helpers.go
@@ -120,6 +120,17 @@ func RequireFlags(cmd *cobra.Command, flags ...string) error {
 	return &ValidationError{Message: "missing required flags: " + strings.Join(missing, ", ")}
 }
 
+// MarkFlagsRequired appends " (required)" to the usage text of each named flag.
+// Call after all flags are registered so --help shows which flags are mandatory.
+func MarkFlagsRequired(cmd *cobra.Command, flags ...string) {
+	for _, name := range flags {
+		f := cmd.Flags().Lookup(name)
+		if f != nil && !strings.HasSuffix(f.Usage, "(required)") {
+			f.Usage += " (required)"
+		}
+	}
+}
+
 // AddEnabledFlag adds --enabled flag accepting "yes" or "no".
 func AddEnabledFlag(cmd *cobra.Command) {
 	cmd.Flags().String("enabled", "", "Enable/disable: yes|no")

--- a/internal/cmd/advanced/command.go
+++ b/internal/cmd/advanced/command.go
@@ -237,6 +237,7 @@ func userGroupWithConfig(app *cliapp.Runtime, use, short, userAPIPath, configGet
 		return app.APIClient.Post(cliapp.APIBase+"/"+userAPIPath, body)
 	})
 	if len(requiredCreateFlags) > 0 {
+		cliapp.MarkFlagsRequired(createCmd, requiredCreateFlags...)
 		origRunE := createCmd.RunE
 		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
 			if err := cliapp.RequireFlags(cmd, requiredCreateFlags...); err != nil {
@@ -370,6 +371,9 @@ func dataCmdImpl(app *cliapp.Runtime, use, short string, withID bool, addFlags f
 	c.Flags().String("data", "{}", "JSON body (escape hatch)")
 	if addFlags != nil {
 		addFlags(c)
+	}
+	if strings.HasPrefix(use, "toggle") {
+		cliapp.MarkFlagsRequired(c, "enabled")
 	}
 	return c
 }

--- a/internal/cmd/network/command.go
+++ b/internal/cmd/network/command.go
@@ -8,6 +8,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// natFlagDescs provides human-readable descriptions for NAT/DNAT CLI flags.
+var natFlagDescs = map[string]string{
+	"name":          "Rule name",
+	"action":        "NAT action (SNAT/DNAT/MASQUERADE)",
+	"protocol":      "Protocol (tcp/udp/any)",
+	"in-interface":  "Inbound interface",
+	"out-interface": "Outbound interface",
+	"comment":       "Comment",
+	"wan-port":      "WAN port",
+	"lan-addr":      "LAN target address",
+	"lan-port":      "LAN target port",
+	"src-addr":      "Source address (comma-separated)",
+	"dst-addr":      "Destination address (comma-separated)",
+	"src-port":      "Source port (comma-separated)",
+	"dst-port":      "Destination port (comma-separated)",
+}
+
 func New(app *cliapp.Runtime) *cobra.Command {
 	networkCmd := &cobra.Command{
 		Use:   "network",
@@ -989,6 +1006,7 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		c.Flags().String("comment", "", "Comment")
 		cliapp.AddEnabledFlag(c)
 	}
+	cliapp.MarkFlagsRequired(networkDNSProxyCreateCmd, "domain", "dns-addr", "parse-type")
 
 	networkCmd.AddCommand(networkDHCPCmd)
 	networkDHCPCmd.AddCommand(
@@ -1034,7 +1052,9 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		c.Flags().String("data", "{}", "JSON body")
 	}
 	cliapp.AddEnabledFlag(networkDHCPToggleCmd)
+	cliapp.MarkFlagsRequired(networkDHCPToggleCmd, "enabled")
 	cliapp.AddEnabledFlag(networkDHCPStaticToggleCmd)
+	cliapp.MarkFlagsRequired(networkDHCPStaticToggleCmd, "enabled")
 	// DHCP access-mode set semantic flags
 	networkDHCPAccessModeSetCmd.Flags().String("mode", "", "Access mode (0=blacklist, 1=whitelist, 2=sync MAC ACL)")
 	// DHCP access-rule create semantic flags
@@ -1056,6 +1076,7 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		c.Flags().String("lease", "", "Lease time")
 		cliapp.AddEnabledFlag(c)
 	}
+	cliapp.MarkFlagsRequired(networkDHCPCreateCmd, "name", "interface", "addr-pool", "netmask", "gateway", "lease", "phy-ifnames")
 	// DHCP static create/update semantic flags
 	for _, c := range []*cobra.Command{networkDHCPStaticCreateCmd, networkDHCPStaticUpdateCmd} {
 		c.Flags().String("name", "", "Binding name")
@@ -1067,6 +1088,8 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		c.Flags().String("comment", "", "Comment")
 		cliapp.AddEnabledFlag(c)
 	}
+	cliapp.MarkFlagsRequired(networkDHCPStaticCreateCmd, "name", "ip", "mac", "interface")
+	cliapp.MarkFlagsRequired(networkDHCPAccessRuleCreateCmd, "name", "mac", "comment")
 
 	networkCmd.AddCommand(networkDHCP6Cmd)
 	networkDHCP6Cmd.AddCommand(
@@ -1094,6 +1117,7 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		c.Flags().String("data", "{}", "JSON body")
 	}
 	cliapp.AddEnabledFlag(networkDHCP6AccessRuleToggleCmd)
+	cliapp.MarkFlagsRequired(networkDHCP6AccessRuleToggleCmd, "enabled")
 
 	networkCmd.AddCommand(networkVLANCmd)
 	networkVLANCmd.AddCommand(
@@ -1108,6 +1132,7 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		c.Flags().String("data", "{}", "JSON body")
 	}
 	cliapp.AddEnabledFlag(networkVLANToggleCmd)
+	cliapp.MarkFlagsRequired(networkVLANToggleCmd, "enabled")
 	// VLAN create/update semantic flags
 	for _, c := range []*cobra.Command{networkVLANCreateCmd, networkVLANUpdateCmd} {
 		c.Flags().String("name", "", "VLAN name")
@@ -1119,6 +1144,7 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		c.Flags().String("comment", "", "Comment")
 		cliapp.AddEnabledFlag(c)
 	}
+	cliapp.MarkFlagsRequired(networkVLANCreateCmd, "name", "vlan-id", "interface", "netmask")
 
 	natFieldMap := map[string]string{
 		"name":          "tagname",
@@ -1263,6 +1289,7 @@ func natGroup(app *cliapp.Runtime, use, short, apiPath string, fieldMap map[stri
 	}
 	toggleCmd.Flags().String("data", "{}", "JSON body")
 	cliapp.AddEnabledFlag(toggleCmd)
+	cliapp.MarkFlagsRequired(toggleCmd, "enabled")
 
 	deleteCmd := newDeleteCmd(app, "Delete a "+use+" rule", "/"+apiPath+"/")
 
@@ -1284,7 +1311,11 @@ func natWriteCmd(app *cliapp.Runtime, use, short string, withID bool, apiPath st
 
 	// Register address/port flags.
 	for flagName := range addrFields {
-		c.Flags().String(flagName, "", "Comma-separated "+flagName+" values")
+		desc := natFlagDescs[flagName]
+		if desc == "" {
+			desc = "Comma-separated " + flagName + " values"
+		}
+		c.Flags().String(flagName, "", desc)
 	}
 
 	if fieldMap != nil {
@@ -1292,7 +1323,11 @@ func natWriteCmd(app *cliapp.Runtime, use, short string, withID bool, apiPath st
 			if flagName == "enabled" {
 				continue
 			}
-			c.Flags().String(flagName, "", flagName+" value")
+			desc := natFlagDescs[flagName]
+			if desc == "" {
+				desc = flagName + " value"
+			}
+			c.Flags().String(flagName, "", desc)
 		}
 		cliapp.AddEnabledFlag(c)
 

--- a/internal/cmd/objects/command.go
+++ b/internal/cmd/objects/command.go
@@ -108,6 +108,9 @@ func objectGroup(app *cliapp.Runtime, name, apiPath string, fieldMap map[string]
 	createCmd.Flags().String("name", "", "Object group name")
 	if valueKey != "" {
 		createCmd.Flags().String("value", "", "Comma-separated values (e.g. 1.2.3.4,5.6.7.8/24)")
+		cliapp.MarkFlagsRequired(createCmd, "name", "value")
+	} else {
+		cliapp.MarkFlagsRequired(createCmd, "name")
 	}
 
 	updateCmd := &cobra.Command{

--- a/internal/cmd/qos/command.go
+++ b/internal/cmd/qos/command.go
@@ -153,6 +153,7 @@ func qosGroup(app *cliapp.Runtime, name, apiPath string, addFlags func(*cobra.Co
 		return app.APIClient.Post(cliapp.APIBase+"/"+apiPath, body)
 	})
 	if len(requiredCreateFlags) > 0 {
+		cliapp.MarkFlagsRequired(createCmd, requiredCreateFlags...)
 		origRunE := createCmd.RunE
 		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
 			if err := cliapp.RequireFlags(cmd, requiredCreateFlags...); err != nil {
@@ -261,6 +262,9 @@ func dataCommandImpl(app *cliapp.Runtime, use, short string, withID bool, addFla
 	c.Flags().String("data", "{}", "JSON body (escape hatch)")
 	if addFlags != nil {
 		addFlags(c)
+	}
+	if strings.HasPrefix(use, "toggle") {
+		cliapp.MarkFlagsRequired(c, "enabled")
 	}
 	return c
 }

--- a/internal/cmd/routing/command.go
+++ b/internal/cmd/routing/command.go
@@ -8,6 +8,36 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// flagDescs provides human-readable descriptions for CLI flags.
+// writeCmd falls back to "flagName value" when a key is absent.
+var flagDescs = map[string]string{
+	// common
+	"name":      "Rule name",
+	"interface": "Outbound interface (e.g. wan1)",
+	"priority":  "Priority (lower = higher)",
+	"comment":   "Comment",
+	// static / five-tuple shared
+	"dst-addr": "Destination address",
+	"gateway":  "Next-hop gateway IP",
+	"netmask":  "Subnet mask",
+	// stream domain
+	"domain": "Domain list (comma-separated)",
+	// stream five-tuple
+	"protocol": "Protocol (tcp/udp/any)",
+	"src-addr": "Source address (comma-separated)",
+	"src-port": "Source port (comma-separated)",
+	"dst-port": "Destination port (comma-separated)",
+	// stream l7
+	"app-proto": "App protocol (comma-separated)",
+	// stream load-balance
+	"mode":     "Balance mode",
+	"weight":   "Weight",
+	"isp-name": "ISP filter (default: all)",
+	// stream updown
+	"upiface":   "Upstream interface",
+	"downiface": "Downstream interface",
+}
+
 // --- Field maps, addr fields, and defaults for stream subcommands ---
 
 var (
@@ -235,6 +265,7 @@ func staticGroup(app *cliapp.Runtime) *cobra.Command {
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/routing/static-routes", body)
 		})
+	cliapp.MarkFlagsRequired(createCmd, "name", "dst-addr", "gateway", "netmask", "interface")
 	{
 		origRunE := createCmd.RunE
 		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -301,6 +332,7 @@ func ruleGroup(app *cliapp.Runtime, use, short, apiPath string, opts ruleGroupOp
 			return app.APIClient.Post(cliapp.APIBase+"/"+apiPath, body)
 		})
 	if len(opts.requiredCreateFlags) > 0 {
+		cliapp.MarkFlagsRequired(createCmd, opts.requiredCreateFlags...)
 		origRunE := createCmd.RunE
 		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
 			if err := cliapp.RequireFlags(cmd, opts.requiredCreateFlags...); err != nil {
@@ -377,13 +409,24 @@ func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[
 		if flagName == "enabled" {
 			continue
 		}
-		c.Flags().String(flagName, "", flagName+" value")
+		desc := flagDescs[flagName]
+		if desc == "" {
+			desc = flagName + " value"
+		}
+		c.Flags().String(flagName, "", desc)
 	}
 	// Register addrFields flags.
 	for flagName := range addrFields {
-		c.Flags().String(flagName, "", "Comma-separated "+flagName+" values")
+		desc := flagDescs[flagName]
+		if desc == "" {
+			desc = "Comma-separated " + flagName + " values"
+		}
+		c.Flags().String(flagName, "", desc)
 	}
 	cliapp.AddEnabledFlag(c)
+	if strings.HasPrefix(use, "toggle") {
+		cliapp.MarkFlagsRequired(c, "enabled")
+	}
 
 	c.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := app.RequireAuth(); err != nil {

--- a/internal/cmd/security/command.go
+++ b/internal/cmd/security/command.go
@@ -8,6 +8,34 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// flagDescs provides human-readable descriptions for CLI flags.
+var flagDescs = map[string]string{
+	"name":          "Rule name",
+	"action":        "Action (accept/drop/reject)",
+	"protocol":      "Protocol (tcp/udp/icmp/any)",
+	"priority":      "Priority (lower = higher)",
+	"comment":       "Comment",
+	"mac":           "MAC address",
+	"limits":        "Connection limit",
+	"domain-group":  "Domain group name",
+	"mode":          "Match mode (0=exact, 1=regex)",
+	"src-url":       "Source URL pattern",
+	"dst-url":       "Destination URL",
+	"ori-keyword":   "Original keyword",
+	"rep-keyword":   "Replacement keyword",
+	"param-keyword": "Parameter keyword",
+	"hit-rate":      "Hit rate threshold",
+	"domain":        "Domain (comma-separated)",
+	"src-addr":      "Source address (comma-separated)",
+	"dst-addr":      "Destination address (comma-separated)",
+	"src-port":      "Source port (comma-separated)",
+	"dst-port":      "Destination port (comma-separated)",
+	"app-proto":     "App protocol (comma-separated)",
+	"direction":     "Direction (forward/in/out)",
+	"in-interface":  "Inbound interface",
+	"out-interface": "Outbound interface",
+}
+
 // Field maps for semantic flags on write commands.
 var (
 	aclFieldMap = map[string]string{
@@ -403,6 +431,7 @@ func addSecCRUD(app *cliapp.Runtime, grp *cobra.Command, apiPath string, withGet
 		return app.APIClient.Post(cliapp.APIBase+"/"+apiPath, body)
 	})
 	if len(requiredCreateFlags) > 0 {
+		cliapp.MarkFlagsRequired(createCmd, requiredCreateFlags...)
 		origRunE := createCmd.RunE
 		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
 			if err := cliapp.RequireFlags(cmd, requiredCreateFlags...); err != nil {
@@ -447,7 +476,11 @@ func secWriteCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap m
 
 	// Register address/port flags.
 	for flagName := range addrFields {
-		c.Flags().String(flagName, "", "Comma-separated "+flagName+" values")
+		desc := flagDescs[flagName]
+		if desc == "" {
+			desc = "Comma-separated " + flagName + " values"
+		}
+		c.Flags().String(flagName, "", desc)
 	}
 
 	if fieldMap != nil {
@@ -531,7 +564,11 @@ func addSemanticFlags(cmd *cobra.Command, fieldMap map[string]string) {
 		if flagName == "enabled" {
 			continue
 		}
-		cmd.Flags().String(flagName, "", "Set "+apiField+" field")
+		desc := flagDescs[flagName]
+		if desc == "" {
+			desc = "Set " + apiField + " field"
+		}
+		cmd.Flags().String(flagName, "", desc)
 	}
 }
 
@@ -605,6 +642,7 @@ func dataCmdImpl(app *cliapp.Runtime, use, short string, withID bool, addFlags f
 	isToggle := strings.HasPrefix(use, "toggle")
 	if isToggle {
 		cliapp.AddEnabledFlag(c)
+		cliapp.MarkFlagsRequired(c, "enabled")
 	}
 	if addFlags != nil {
 		addFlags(c)

--- a/internal/cmd/system/command.go
+++ b/internal/cmd/system/command.go
@@ -600,6 +600,7 @@ SSH credentials are resolved in order:
 		c.Flags().String("data", "{}", "JSON body")
 	}
 	cliapp.AddEnabledFlag(systemSchedulesToggleCmd)
+	cliapp.MarkFlagsRequired(systemSchedulesToggleCmd, "enabled")
 	for _, c := range []*cobra.Command{systemSchedulesCreateCmd, systemSchedulesUpdateCmd} {
 		c.Flags().String("name", "", "Schedule name (tagname)")
 		c.Flags().String("event", "", "Event type (reboot/poweroff)")
@@ -609,6 +610,7 @@ SSH credentials are resolved in order:
 		c.Flags().String("comment", "", "Comment")
 		cliapp.AddEnabledFlag(c)
 	}
+	cliapp.MarkFlagsRequired(systemSchedulesCreateCmd, "name", "time", "strategy", "cycle-time")
 
 	systemCmd.AddCommand(
 		systemRemoteAccessCmd,

--- a/internal/cmd/users/command.go
+++ b/internal/cmd/users/command.go
@@ -8,6 +8,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// flagDescs provides human-readable descriptions for CLI flags.
+var flagDescs = map[string]string{
+	"username":   "Login username",
+	"password":   "Login password",
+	"ppptype":    "PPP type (any/pppoe/pptp/l2tp)",
+	"upload":     "Upload bandwidth limit (KB/s, 0=unlimited)",
+	"download":   "Download bandwidth limit (KB/s, 0=unlimited)",
+	"share":      "Max concurrent sessions",
+	"comment":    "Comment",
+	"name":       "Package name",
+	"time":       "Duration (hours)",
+	"price":      "Price",
+	"up-speed":   "Upload speed limit (KB/s)",
+	"down-speed": "Download speed limit (KB/s)",
+}
+
 var (
 	accountFieldMap = map[string]string{
 		"username": "username",
@@ -136,6 +152,7 @@ func accountsGroup(app *cliapp.Runtime) *cobra.Command {
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/auth/users", body)
 		})
+	cliapp.MarkFlagsRequired(createCmd, "username", "password")
 	{
 		origRunE := createCmd.RunE
 		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -185,6 +202,7 @@ func packagesGroup(app *cliapp.Runtime) *cobra.Command {
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/auth/packages", body)
 		})
+	cliapp.MarkFlagsRequired(pkgCreateCmd, "name", "time", "price", "up-speed", "down-speed")
 	{
 		origRunE := pkgCreateCmd.RunE
 		pkgCreateCmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -270,12 +288,23 @@ func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[
 		if flagName == "enabled" {
 			continue
 		}
-		c.Flags().String(flagName, "", flagName+" value")
+		desc := flagDescs[flagName]
+		if desc == "" {
+			desc = flagName + " value"
+		}
+		c.Flags().String(flagName, "", desc)
 	}
 	for flagName := range addrFields {
-		c.Flags().String(flagName, "", "Comma-separated "+flagName+" values")
+		desc := flagDescs[flagName]
+		if desc == "" {
+			desc = "Comma-separated " + flagName + " values"
+		}
+		c.Flags().String(flagName, "", desc)
 	}
 	cliapp.AddEnabledFlag(c)
+	if strings.HasPrefix(use, "toggle") {
+		cliapp.MarkFlagsRequired(c, "enabled")
+	}
 
 	c.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := app.RequireAuth(); err != nil {

--- a/internal/cmd/vpn/command.go
+++ b/internal/cmd/vpn/command.go
@@ -8,6 +8,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// flagDescs provides human-readable descriptions for CLI flags.
+var flagDescs = map[string]string{
+	"name":         "Tunnel/client name",
+	"server":       "VPN server address",
+	"remote-addr":  "Remote server address",
+	"username":     "Authentication username",
+	"password":     "Authentication password",
+	"interface":    "Bound interface (e.g. wan1, auto)",
+	"comment":      "Comment",
+	"left-id":      "Local identity string",
+	"left-subnet":  "Local subnet (CIDR)",
+	"right-subnet": "Remote subnet (CIDR)",
+	"secret":       "Pre-shared key",
+	"address":      "Tunnel address (CIDR)",
+	"private-key":  "WireGuard private key (base64)",
+	"public-key":   "WireGuard public key (base64)",
+	"allow-ips":    "Allowed IPs (CIDR, comma-separated)",
+	"port":         "Listen port",
+	"mtu":          "MTU size",
+	"keepalive":    "Persistent keepalive interval (seconds)",
+	"ca":           "CA certificate (PEM)",
+}
+
 // --- VPN client field maps and defaults ---
 
 var (
@@ -300,6 +323,7 @@ func vpnServerGroup(app *cliapp.Runtime, name, apiPath string, clientFieldMap ma
 			return app.APIClient.Post(cliapp.APIBase+"/"+apiPath+"/clients", body)
 		})
 	if len(requiredCreateFlags) > 0 {
+		cliapp.MarkFlagsRequired(clientCreateCmd, requiredCreateFlags...)
 		origRunE := clientCreateCmd.RunE
 		clientCreateCmd.RunE = func(cmd *cobra.Command, args []string) error {
 			if err := cliapp.RequireFlags(cmd, requiredCreateFlags...); err != nil {
@@ -345,6 +369,7 @@ func ipsecGroup(app *cliapp.Runtime) *cobra.Command {
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/vpn/ipsec/clients", body)
 		})
+	cliapp.MarkFlagsRequired(createCmd, "name", "interface", "left-subnet", "right-subnet")
 	{
 		origRunE := createCmd.RunE
 		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -422,6 +447,7 @@ func wireguardGroup(app *cliapp.Runtime) *cobra.Command {
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/vpn/wireguard", body)
 		})
+	cliapp.MarkFlagsRequired(wgCreateCmd, "name", "address", "private-key", "public-key")
 	{
 		origRunE := wgCreateCmd.RunE
 		wgCreateCmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -435,6 +461,7 @@ func wireguardGroup(app *cliapp.Runtime) *cobra.Command {
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/vpn/wireguard/"+id+"/peers", body)
 		})
+	cliapp.MarkFlagsRequired(peerCreateCmd, "public-key", "allow-ips", "interface")
 	{
 		origRunE := peerCreateCmd.RunE
 		peerCreateCmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -553,12 +580,23 @@ func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[
 		if flagName == "enabled" {
 			continue
 		}
-		c.Flags().String(flagName, "", flagName+" value")
+		desc := flagDescs[flagName]
+		if desc == "" {
+			desc = flagName + " value"
+		}
+		c.Flags().String(flagName, "", desc)
 	}
 	for flagName := range addrFields {
-		c.Flags().String(flagName, "", "Comma-separated "+flagName+" values")
+		desc := flagDescs[flagName]
+		if desc == "" {
+			desc = "Comma-separated " + flagName + " values"
+		}
+		c.Flags().String(flagName, "", desc)
 	}
 	cliapp.AddEnabledFlag(c)
+	if strings.HasPrefix(use, "toggle") {
+		cliapp.MarkFlagsRequired(c, "enabled")
+	}
 
 	c.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := app.RequireAuth(); err != nil {

--- a/internal/cmd/wireless/command.go
+++ b/internal/cmd/wireless/command.go
@@ -8,6 +8,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// flagDescs provides human-readable descriptions for CLI flags.
+var flagDescs = map[string]string{
+	"name":    "Rule name",
+	"mode":    "Mode (0=blacklist, 1=whitelist)",
+	"ssid":    "SSID filter (default: ALL)",
+	"ap":      "AP filter (default: ALL)",
+	"mac":     "MAC address (comma-separated)",
+	"week":    "Active days (e.g. 1234567)",
+	"time":    "Active time range (e.g. 00:00-23:59)",
+	"vlan-id": "VLAN ID",
+	"comment": "Comment",
+}
+
 // --- Field maps, addr fields, and defaults for wireless subcommands ---
 
 var (
@@ -116,6 +129,7 @@ func ruleGroup(app *cliapp.Runtime, use, short, apiPath string, opts ruleGroupOp
 			return app.APIClient.Post(cliapp.APIBase+"/"+apiPath, body)
 		})
 	if len(opts.requiredCreateFlags) > 0 {
+		cliapp.MarkFlagsRequired(createCmd, opts.requiredCreateFlags...)
 		origRunE := createCmd.RunE
 		createCmd.RunE = func(cmd *cobra.Command, args []string) error {
 			if err := cliapp.RequireFlags(cmd, opts.requiredCreateFlags...); err != nil {
@@ -319,12 +333,23 @@ func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[
 		if flagName == "enabled" {
 			continue
 		}
-		c.Flags().String(flagName, "", flagName+" value")
+		desc := flagDescs[flagName]
+		if desc == "" {
+			desc = flagName + " value"
+		}
+		c.Flags().String(flagName, "", desc)
 	}
 	for flagName := range addrFields {
-		c.Flags().String(flagName, "", "Comma-separated "+flagName+" values")
+		desc := flagDescs[flagName]
+		if desc == "" {
+			desc = "Comma-separated " + flagName + " values"
+		}
+		c.Flags().String(flagName, "", desc)
 	}
 	cliapp.AddEnabledFlag(c)
+	if strings.HasPrefix(use, "toggle") {
+		cliapp.MarkFlagsRequired(c, "enabled")
+	}
 
 	c.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := app.RequireAuth(); err != nil {


### PR DESCRIPTION
- 新增 MarkFlagsRequired helper，必填 flag 显示 (required) 标注
- routing/vpn/users/wireless: writeCmd 用 flagDescs 替代 "xxx value"
- security: addSemanticFlags/secWriteCmd 用 flagDescs 替代 "Set xxx field"
- network: natWriteCmd 用 natFlagDescs，inline create/toggle 加标注
- advanced/qos/system/objects: 补 MarkFlagsRequired 标注
- 所有 toggle 命令的 --enabled 标注 (required)
