### PR TITLE
Complete security command regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ ikuai-cli network dns get                    # DNS config
 ikuai-cli network dns proxy create --domain example.com --dns-addr 8.8.8.8 --parse-type ipv4
 ikuai-cli network pppoe set --comment maintenance --mtu 1480 --mru 1480
 ikuai-cli users online                       # Online users
-ikuai-cli security acl list                  # Firewall rules
+ikuai-cli security acl list                  # Security rules
 ikuai-cli log system list --human-time       # System logs
 ```
 
@@ -106,7 +106,7 @@ ikuai-cli log system list --human-time       # System logs
 
 - **Network** — DNS, DHCP, VLAN, NAT, PPPoE, interfaces
 - **Monitor** — CPU, memory, uptime, traffic, online users
-- **Security** — firewall rules, access control, URL filtering
+- **Security** — ACL, MAC filtering, L7 rules, URL filtering, domain blacklist, peerconn, terminals
 - **Users** — account management, auth-server, bandwidth limits
 - **Routing** — static routes, policy routing, multi-WAN
 - **VPN** — IPSec, PPTP, L2TP, WireGuard
@@ -156,7 +156,7 @@ ikuai-cli ships with a [`SKILL.md`](./SKILL.md) and 7 domain-specific [skills](.
 | [monitor](skills/monitor.md) | System status, CPU, memory, traffic, online clients |
 | [network](skills/network.md) | DNS, DHCP, VLAN, NAT, WAN, LAN, PPPoE |
 | [users](skills/users.md) | Online users, kick, accounts, packages |
-| [security](skills/security.md) | ACL, MAC filter, URL filter, domain blacklist |
+| [security](skills/security.md) | ACL, MAC filter, L7, URL filter, domain blacklist, peerconn, terminals |
 | [vpn](skills/vpn.md) | PPTP, L2TP, OpenVPN, IKEv2, IPSec, WireGuard |
 | [system](skills/system.md) | Config, schedules, remote access, VRRP, SSH reset |
 | [batch](skills/batch.md) | Multi-command workflows: init, bulk DHCP, backup |

--- a/README_CN.md
+++ b/README_CN.md
@@ -96,7 +96,7 @@ ikuai-cli network dns get                    # DNS 配置
 ikuai-cli network dns proxy create --domain example.com --dns-addr 8.8.8.8 --parse-type ipv4
 ikuai-cli network pppoe set --comment maintenance --mtu 1480 --mru 1480
 ikuai-cli users online                       # 在线用户
-ikuai-cli security acl list                  # 防火墙规则
+ikuai-cli security acl list                  # 安全策略
 ikuai-cli log system list --human-time       # 系统日志
 ```
 
@@ -106,7 +106,7 @@ ikuai-cli log system list --human-time       # 系统日志
 
 - **网络管理** — DNS、DHCP、VLAN、NAT、PPPoE、网口配置
 - **系统监控** — CPU、内存、运行时间、流量、在线用户
-- **安全策略** — 防火墙规则、访问控制、URL 过滤
+- **安全策略** — ACL、MAC 过滤、L7 规则、URL 过滤、域名黑名单、连接数限制、终端标注
 - **用户管理** — 账号管理、认证服务器、带宽限制
 - **路由配置** — 静态路由、策略路由、多 WAN 负载均衡
 - **VPN** — IPSec、PPTP、L2TP、WireGuard
@@ -156,7 +156,7 @@ ikuai-cli 内置 [`SKILL.md`](./SKILL.md) 和 7 个领域 [skills](./skills/)，
 | [monitor](skills/monitor.md) | 系统状态、CPU、内存、流量、在线客户端 |
 | [network](skills/network.md) | DNS、DHCP、VLAN、NAT、WAN、LAN、PPPoE |
 | [users](skills/users.md) | 在线用户、踢下线、账户、套餐 |
-| [security](skills/security.md) | ACL、MAC 过滤、URL 过滤、域名黑名单 |
+| [security](skills/security.md) | ACL、MAC 过滤、L7、URL 过滤、域名黑名单、连接数限制、终端标注 |
 | [vpn](skills/vpn.md) | PPTP、L2TP、OpenVPN、IKEv2、IPSec、WireGuard |
 | [system](skills/system.md) | 系统配置、定时任务、远程访问、VRRP、SSH 重置 |
 | [batch](skills/batch.md) | 组合工作流：初始化、批量 DHCP、配置备份 |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -127,11 +127,15 @@ ikuai-cli system web-passwd reset --ssh-user root --yes
 
 ```bash
 ikuai-cli security acl list
-ikuai-cli security acl create --name "BlockSSH" --action drop --protocol tcp --direction in --priority 100
+ikuai-cli security acl create --name "BlockSSH" --action drop --protocol tcp --direction forward --dst-port 22 --priority 30 --enabled no
 ikuai-cli security mac get-mode
-ikuai-cli security url list
+ikuai-cli security mac set-mode --acl-mac 0
+ikuai-cli security url black list
+ikuai-cli security url keywords create --name "KW1" --mode exact --src-url "example.com" --ori-keyword "bad" --rep-keyword "good" --hit-rate 1 --priority 10 --enabled no
 ikuai-cli security domain-blacklist list
 ikuai-cli security l7 list
+ikuai-cli security advanced-get
+ikuai-cli security secondary-route-get
 ```
 
 ## VPN

--- a/internal/cliapp/helpers.go
+++ b/internal/cliapp/helpers.go
@@ -77,6 +77,11 @@ var integerAPIFields = map[string]bool{
 	"bind_vlan": true, "verify_vlan": true, "bind_iface": true,
 	"mtu": true, "mru": true, "lcp_echo_interval": true,
 	"lcp_echo_failure": true, "maxconnect": true, "restart_timer": true,
+	"acl_mac": true, "mode": true,
+	"noping_lan": true, "noping_wan": true, "notracert": true,
+	"hijack_ping": true, "invalid": true, "dos_lan": true,
+	"dos_lan_num": true, "tcp_mss": true, "tcp_mss_num": true,
+	"nol2rt": true, "ttl_num": true,
 }
 
 // MergeDataWithFlags parses --data JSON, then overlays any explicitly set

--- a/internal/cmd/security/behavior_test.go
+++ b/internal/cmd/security/behavior_test.go
@@ -84,8 +84,8 @@ func TestMACSetModeSendsExpectedJSONBody(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ReadAll() error = %v", err)
 			}
-			if string(body) != `{"mode":"blacklist"}` {
-				t.Fatalf("body = %q, want %q", string(body), `{"mode":"blacklist"}`)
+			if string(body) != `{"acl_mac":1}` {
+				t.Fatalf("body = %q, want %q", string(body), `{"acl_mac":1}`)
 			}
 
 			return jsonResponse(`{"code":0,"message":"saved","data":null}`), nil
@@ -93,7 +93,7 @@ func TestMACSetModeSendsExpectedJSONBody(t *testing.T) {
 	})
 
 	cmd := New(app)
-	cmd.SetArgs([]string{"mac", "set-mode", "--data", `{"mode":"blacklist"}`})
+	cmd.SetArgs([]string{"mac", "set-mode", "--acl-mac", "1"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -102,6 +102,80 @@ func TestMACSetModeSendsExpectedJSONBody(t *testing.T) {
 	want := "{\"message\":\"saved\"}\n"
 	if got != want {
 		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestSecurityUpdateUsesFullBodyFromGet(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-sec"}
+	step := 0
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			step++
+			switch step {
+			case 1:
+				if req.Method != http.MethodGet {
+					t.Fatalf("step 1 method = %q, want GET", req.Method)
+				}
+				if req.URL.Path != "/api/v4.0/security/acl-rules/42" {
+					t.Fatalf("step 1 path = %q", req.URL.Path)
+				}
+				return jsonResponse(`{"code":0,"data":{"id":42,"enabled":"yes","tagname":"old","action":"drop","protocol":"tcp","dir":"forward","ctdir":0,"iinterface":"any","ointerface":"any","prio":50,"src_addr":{"custom":[],"object":[]},"dst_addr":{"custom":[],"object":[]},"src_port":{"custom":[],"object":[]},"dst_port":{"custom":[],"object":[]},"src_addr_inv":0,"dst_addr_inv":0,"src6_mode":0,"dst6_mode":0}}`), nil
+			case 2:
+				if req.Method != http.MethodPut {
+					t.Fatalf("step 2 method = %q, want PUT", req.Method)
+				}
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("ReadAll() error = %v", err)
+				}
+				got := string(body)
+				if strings.Contains(got, `"id"`) {
+					t.Fatalf("body should not include id: %s", got)
+				}
+				for _, want := range []string{`"tagname":"new-name"`, `"action":"drop"`, `"protocol":"tcp"`, `"dir":"forward"`} {
+					if !strings.Contains(got, want) {
+						t.Fatalf("body = %s, missing %s", got, want)
+					}
+				}
+				return jsonResponse(`{"code":0,"message":"saved","data":null}`), nil
+			default:
+				t.Fatalf("unexpected request %d: %s %s", step, req.Method, req.URL.String())
+			}
+			return nil, nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"acl", "update", "42", "--name", "new-name"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if step != 2 {
+		t.Fatalf("requests = %d, want 2", step)
+	}
+}
+
+func TestTerminalsDoesNotExposeToggle(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "tok"}
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"terminals", "toggle", "1", "--enabled", "no"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected unknown command error")
+	}
+	if !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("error = %q, want unknown command/flag", err.Error())
 	}
 }
 

--- a/internal/cmd/security/command.go
+++ b/internal/cmd/security/command.go
@@ -228,6 +228,9 @@ var (
 		"domain":   "domain",
 		"src-addr": "src_addr",
 	}
+	urlStringModeFlags = map[string]string{
+		"mode": "Match mode (exact/vague)",
+	}
 
 	domainBlacklistCreateDefaults = map[string]interface{}{
 		"enabled": "yes",
@@ -262,8 +265,12 @@ var (
 
 	// secondary-route-set fields
 	secondaryRouteFieldMap = map[string]string{
-		"nol2rt":  "nol2rt",
-		"ttl-num": "ttl_num",
+		"nol2rt":    "nol2rt",
+		"nol2rt-ip": "nol2rt_ip",
+		"ttl-num":   "ttl_num",
+	}
+	secondaryRouteAddrFields = map[string]string{
+		"nol2rt-ip": "nol2rt_ip",
 	}
 )
 
@@ -273,9 +280,11 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		Short: "Security rules",
 		Long:  `Manage security rules: ACL, MAC filtering, L7 application rules, URL filtering, domain blacklist, connection limits, and terminals.`,
 		Example: `  ikuai-cli security acl list
-  ikuai-cli security acl create --name "block_ssh" --action drop --protocol tcp --dst-port "22" --enabled yes
-  ikuai-cli security mac list
-  ikuai-cli security l7 list`,
+  ikuai-cli security acl create --name "block_ssh" --action drop --protocol tcp --dst-port "22" --priority 30 --enabled no
+  ikuai-cli security mac get-mode
+  ikuai-cli security mac set-mode --acl-mac 0
+  ikuai-cli security l7 create --name "block_app" --action drop --app-proto "抖音短视频" --priority 30 --enabled no
+  ikuai-cli security url keywords create --name "kw1" --mode exact --src-url "example.com" --ori-keyword "bad" --rep-keyword "good" --hit-rate 1 --priority 10 --enabled no`,
 	}
 
 	securityCmd.AddCommand(secGroup(app, "acl", "IP ACL rules", "security/acl-rules", true, aclFieldMap, secGroupOpts{
@@ -302,62 +311,67 @@ func New(app *cliapp.Runtime) *cobra.Command {
 				return nil
 			},
 		},
-		dataCmdWithFlags(app, "set-mode", "Set MAC filter mode", func(c *cobra.Command) {
-			c.Flags().String("acl-mac", "", "MAC mode (0=blacklist, 1=whitelist)")
-		}, macModeFieldMap, func(body interface{}, id string) (json.RawMessage, error) {
-			return app.APIClient.Put(cliapp.APIBase+"/security/mac-mode", body)
-		}),
+		macSetModeCmd(app),
 	)
-	addSecCRUD(app, macCmd, "security/mac-rules", false, macFieldMap, macCreateDefaults, nil, nil, []string{"name", "mac"})
+	addSecCRUD(app, macCmd, "security/mac-rules", true, macFieldMap, macCreateDefaults, []string{"id", "tagname", "mac", "enabled"}, nil, []string{"name", "mac"}, false, nil)
 	securityCmd.AddCommand(macCmd)
 
 	securityCmd.AddCommand(secGroup(app, "l7", "L7 application-layer rules", "security/app-protocols/professional/rules", true, l7FieldMap, secGroupOpts{
 		createDefaults:      l7CreateDefaults,
+		defaultColumns:      []string{"id", "tagname", "action", "app_proto", "prio", "enabled"},
 		addrFields:          l7AddrFields,
-		requiredCreateFlags: []string{"name", "action", "priority"},
+		requiredCreateFlags: []string{"name", "action", "priority", "app-proto"},
 	}))
 
 	urlCmd := &cobra.Command{Use: "url", Short: "URL filter rules"}
 	urlCmd.AddCommand(
-		secGroup(app, "black", "URL blacklist rules", "security/url-black/rules", false, urlBlackFieldMap, secGroupOpts{
+		secGroup(app, "black", "URL blacklist rules", "security/url-black/rules", true, urlBlackFieldMap, secGroupOpts{
 			createDefaults:      urlBlackCreateDefaults,
+			defaultColumns:      []string{"id", "tagname", "mode", "domain", "enabled"},
 			addrFields:          urlBlackAddrFields,
-			requiredCreateFlags: []string{"name", "mode"},
+			requiredCreateFlags: []string{"name", "mode", "domain"},
 		}),
-		secGroup(app, "keywords", "URL keyword rules", "security/url-keywords/rules", false, urlKeywordsFieldMap, secGroupOpts{
+		secGroup(app, "keywords", "URL keyword rules", "security/url-keywords/rules", true, urlKeywordsFieldMap, secGroupOpts{
 			createDefaults:      urlKeywordsCreateDefaults,
 			defaultColumns:      []string{"id", "tagname", "mode", "src_url", "ori_keyword", "rep_keyword", "hit_rate", "prio", "enabled"},
 			requiredCreateFlags: []string{"name", "mode", "src-url", "ori-keyword", "rep-keyword", "hit-rate", "priority"},
+			flagDescs:           urlStringModeFlags,
 		}),
-		secGroup(app, "redirect", "URL redirect rules", "security/url-redirect/rules", false, urlRedirectFieldMap, secGroupOpts{
+		secGroup(app, "redirect", "URL redirect rules", "security/url-redirect/rules", true, urlRedirectFieldMap, secGroupOpts{
 			createDefaults:      urlRedirectCreateDefaults,
 			defaultColumns:      []string{"id", "tagname", "mode", "src_url", "dst_url", "hit_rate", "prio", "enabled"},
 			requiredCreateFlags: []string{"name", "mode", "src-url", "dst-url", "hit-rate", "priority"},
+			flagDescs:           urlStringModeFlags,
 		}),
-		secGroup(app, "replace", "URL replace rules", "security/url-replace/rules", false, urlReplaceFieldMap, secGroupOpts{
+		secGroup(app, "replace", "URL replace rules", "security/url-replace/rules", true, urlReplaceFieldMap, secGroupOpts{
 			createDefaults:      urlReplaceCreateDefaults,
 			defaultColumns:      []string{"id", "tagname", "mode", "src_url", "param_keyword", "rep_keyword", "hit_rate", "prio", "enabled"},
 			requiredCreateFlags: []string{"name", "mode", "src-url", "param-keyword", "rep-keyword", "hit-rate", "priority"},
+			flagDescs:           urlStringModeFlags,
 		}),
 	)
 	securityCmd.AddCommand(urlCmd)
 
-	securityCmd.AddCommand(secGroup(app, "domain-blacklist", "Domain blacklist rules", "security/domain-blacklist/rules", false, domainBlacklistFieldMap, secGroupOpts{
+	securityCmd.AddCommand(secGroup(app, "domain-blacklist", "Domain blacklist rules", "security/domain-blacklist/rules", true, domainBlacklistFieldMap, secGroupOpts{
 		createDefaults:      domainBlacklistCreateDefaults,
+		defaultColumns:      []string{"id", "tagname", "domain_group", "enabled"},
 		requiredCreateFlags: []string{"name", "domain-group"},
 	}))
-	securityCmd.AddCommand(secGroup(app, "peerconn", "Peer connection rules", "security/peerconn/rules", false, peerconnFieldMap, secGroupOpts{
+	securityCmd.AddCommand(secGroup(app, "peerconn", "Peer connection rules", "security/peerconn/rules", true, peerconnFieldMap, secGroupOpts{
 		createDefaults:      peerconnCreateDefaults,
+		defaultColumns:      []string{"id", "tagname", "protocol", "limits", "dst_port", "enabled"},
 		addrFields:          peerconnAddrFields,
 		requiredCreateFlags: []string{"name", "limits", "protocol"},
 	}))
-	securityCmd.AddCommand(secGroup(app, "terminals", "Terminal device annotations", "security/terminals", false, terminalsFieldMap))
+	securityCmd.AddCommand(secGroup(app, "terminals", "Terminal device annotations", "security/terminals", true, terminalsFieldMap, secGroupOpts{
+		defaultColumns:      []string{"id", "tagname", "mac", "comment"},
+		requiredCreateFlags: []string{"name", "mac"},
+		disableToggle:       true,
+	}))
 
 	securityCmd.AddCommand(
-		dataCmd(app, "advanced-get", "Get advanced security config", func(body interface{}, id string) (json.RawMessage, error) {
-			return app.APIClient.Get(cliapp.APIBase+"/security/advanced/config", nil)
-		}),
-		dataCmdWithFlags(app, "advanced-set", "Set advanced security config", func(c *cobra.Command) {
+		configGetCmd(app, "advanced-get", "Get advanced security config", "/security/advanced/config", []string{"id", "noping_lan", "noping_wan", "notracert", "invalid", "dos_lan", "dos_lan_num", "tcp_mss", "tcp_mss_num"}),
+		configSetCmd(app, "advanced-set", "Set advanced security config", "/security/advanced/config", func(c *cobra.Command) {
 			c.Flags().String("noping-lan", "", "Block LAN ping (0/1)")
 			c.Flags().String("noping-wan", "", "Block WAN ping (0/1)")
 			c.Flags().String("notracert", "", "Block tracert (0/1)")
@@ -367,22 +381,25 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			c.Flags().String("dos-lan-num", "", "LAN DoS connection limit")
 			c.Flags().String("tcp-mss", "", "Enable TCP MSS (0/1)")
 			c.Flags().String("tcp-mss-num", "", "TCP MSS max segment size")
-		}, advancedFieldMap, func(body interface{}, id string) (json.RawMessage, error) {
-			return app.APIClient.Put(cliapp.APIBase+"/security/advanced/config", body)
-		}),
-		dataCmd(app, "secondary-route-get", "Get secondary (L2) route config", func(body interface{}, id string) (json.RawMessage, error) {
-			return app.APIClient.Get(cliapp.APIBase+"/security/secondary-route/config", nil)
-		}),
-		dataCmdWithFlags(app, "secondary-route-set", "Set secondary (L2) route config", func(c *cobra.Command) {
+		}, advancedFieldMap, nil),
+		configGetCmd(app, "secondary-route-get", "Get secondary (L2) route config", "/security/secondary-route/config", []string{"id", "nol2rt", "nol2rt_ip", "ttl_num", "time"}),
+		configSetCmd(app, "secondary-route-set", "Set secondary (L2) route config", "/security/secondary-route/config", func(c *cobra.Command) {
 			c.Flags().String("nol2rt", "", "Block secondary routers (0=allow, 1=block)")
 			c.Flags().String("nol2rt-ip", "", "IP addresses (comma-separated)")
 			c.Flags().String("ttl-num", "", "Custom TTL value (1-255)")
-		}, secondaryRouteFieldMap, func(body interface{}, id string) (json.RawMessage, error) {
-			return app.APIClient.Put(cliapp.APIBase+"/security/secondary-route/config", body)
-		}),
+		}, secondaryRouteFieldMap, secondaryRouteAddrFields),
 	)
 
 	return securityCmd
+}
+
+func configGetCmd(app *cliapp.Runtime, use, short, apiPath string, defaultColumns []string) *cobra.Command {
+	return dataCmd(app, use, short, func(body interface{}, id string) (json.RawMessage, error) {
+		if len(defaultColumns) > 0 {
+			app.DefaultColumns = defaultColumns
+		}
+		return app.APIClient.Get(cliapp.APIBase+apiPath, nil)
+	})
 }
 
 type secGroupOpts struct {
@@ -390,6 +407,8 @@ type secGroupOpts struct {
 	defaultColumns      []string
 	addrFields          map[string]string // CLI flag → API field for address/port nested objects.
 	requiredCreateFlags []string
+	disableToggle       bool
+	flagDescs           map[string]string
 }
 
 func secGroup(app *cliapp.Runtime, use, short, apiPath string, withGet bool, fieldMap map[string]string, opts ...secGroupOpts) *cobra.Command {
@@ -398,11 +417,11 @@ func secGroup(app *cliapp.Runtime, use, short, apiPath string, withGet bool, fie
 	if len(opts) > 0 {
 		o = opts[0]
 	}
-	addSecCRUD(app, grp, apiPath, withGet, fieldMap, o.createDefaults, o.defaultColumns, o.addrFields, o.requiredCreateFlags)
+	addSecCRUD(app, grp, apiPath, withGet, fieldMap, o.createDefaults, o.defaultColumns, o.addrFields, o.requiredCreateFlags, o.disableToggle, o.flagDescs)
 	return grp
 }
 
-func addSecCRUD(app *cliapp.Runtime, grp *cobra.Command, apiPath string, withGet bool, fieldMap map[string]string, createDefaults map[string]interface{}, defaultColumns []string, addrFields map[string]string, requiredCreateFlags []string) {
+func addSecCRUD(app *cliapp.Runtime, grp *cobra.Command, apiPath string, withGet bool, fieldMap map[string]string, createDefaults map[string]interface{}, defaultColumns []string, addrFields map[string]string, requiredCreateFlags []string, disableToggle bool, customFlagDescs map[string]string) {
 	name := grp.Use
 	listCmd := &cobra.Command{
 		Use:     "list",
@@ -429,7 +448,7 @@ func addSecCRUD(app *cliapp.Runtime, grp *cobra.Command, apiPath string, withGet
 
 	createCmd := secWriteCmd(app, "create", "Create a "+name+" rule", false, fieldMap, createDefaults, addrFields, func(body interface{}, id string) (json.RawMessage, error) {
 		return app.APIClient.Post(cliapp.APIBase+"/"+apiPath, body)
-	})
+	}, "", customFlagDescs)
 	if len(requiredCreateFlags) > 0 {
 		cliapp.MarkFlagsRequired(createCmd, requiredCreateFlags...)
 		origRunE := createCmd.RunE
@@ -442,20 +461,22 @@ func addSecCRUD(app *cliapp.Runtime, grp *cobra.Command, apiPath string, withGet
 	}
 	updateCmd := secWriteCmd(app, "update ID", "Update a "+name+" rule", true, fieldMap, nil, addrFields, func(body interface{}, id string) (json.RawMessage, error) {
 		return app.APIClient.Put(cliapp.APIBase+"/"+apiPath+"/"+id, body)
-	})
+	}, cliapp.APIBase+"/"+apiPath+"/", customFlagDescs)
 
 	grp.AddCommand(
 		listCmd,
 		createCmd,
 		updateCmd,
-		dataCmdWithID(app, "toggle ID", "Enable/disable a "+name+" rule (--data JSON)", func(body interface{}, id string) (json.RawMessage, error) {
-			return app.APIClient.Patch(cliapp.APIBase+"/"+apiPath+"/"+id, body)
-		}),
 		deleteByIDCmd(app, "delete ID", "Delete a "+name+" rule", "/"+apiPath+"/"),
 	)
+	if !disableToggle {
+		grp.AddCommand(dataCmdWithID(app, "toggle ID", "Enable/disable a "+name+" rule", func(body interface{}, id string) (json.RawMessage, error) {
+			return app.APIClient.Patch(cliapp.APIBase+"/"+apiPath+"/"+id, body)
+		}))
+	}
 
 	if withGet {
-		grp.AddCommand(getByIDCmd(app, "get ID", "Get a single "+name+" rule", "/"+apiPath+"/"))
+		grp.AddCommand(getByIDCmd(app, "get ID", "Get a single "+name+" rule", "/"+apiPath+"/", defaultColumns))
 	}
 }
 
@@ -464,7 +485,7 @@ func addSecCRUD(app *cliapp.Runtime, grp *cobra.Command, apiPath string, withGet
 // it falls back to the plain --data / ParseJSON path.
 // addrFields maps CLI flag names to API field names for address/port nested objects;
 // these flags accept comma-separated values and build {"custom": [...], "object": []} structures.
-func secWriteCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[string]string, defaults map[string]interface{}, addrFields map[string]string, fn callWithBody) *cobra.Command {
+func secWriteCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[string]string, defaults map[string]interface{}, addrFields map[string]string, fn callWithBody, baseGetPath string, customFlagDescs map[string]string) *cobra.Command {
 	c := &cobra.Command{Use: use, Short: short}
 	if use == "create" {
 		c.Aliases = []string{"new"}
@@ -484,7 +505,7 @@ func secWriteCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap m
 	}
 
 	if fieldMap != nil {
-		addSemanticFlags(c, fieldMap)
+		addSemanticFlags(c, fieldMap, customFlagDescs)
 		cliapp.AddEnabledFlag(c)
 
 		c.RunE = func(cmd *cobra.Command, args []string) error {
@@ -496,31 +517,23 @@ func secWriteCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap m
 			if err != nil {
 				return err
 			}
+			if withID && baseGetPath != "" {
+				full, err := fullBodyFromGet(app, baseGetPath+args[0])
+				if err != nil {
+					return err
+				}
+				for k, v := range body {
+					full[k] = v
+				}
+				body = full
+			}
 			// Apply defaults: only fill keys not already set by --data or flags.
 			for k, v := range defaults {
 				if _, exists := body[k]; !exists {
 					body[k] = v
 				}
 			}
-			// Parse address/port flags into nested objects.
-			for flagName, apiField := range addrFields {
-				f := cmd.Flags().Lookup(flagName)
-				if f == nil || !f.Changed {
-					continue
-				}
-				parts := strings.Split(f.Value.String(), ",")
-				custom := make([]interface{}, 0, len(parts))
-				for _, v := range parts {
-					v = strings.TrimSpace(v)
-					if v != "" {
-						custom = append(custom, v)
-					}
-				}
-				body[apiField] = map[string]interface{}{
-					"custom": custom,
-					"object": []interface{}{},
-				}
-			}
+			applyAddrFields(body, cmd, addrFields)
 			id := ""
 			if withID {
 				id = args[0]
@@ -557,14 +570,141 @@ func secWriteCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap m
 	return c
 }
 
+func fullBodyFromGet(app *cliapp.Runtime, path string) (map[string]interface{}, error) {
+	dryRun := app.APIClient.DryRun
+	app.APIClient.DryRun = false
+	defer func() { app.APIClient.DryRun = dryRun }()
+	raw, err := app.APIClient.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil, err
+	}
+	if rows, ok := body["data"].([]interface{}); ok && len(rows) > 0 {
+		if row, ok := rows[0].(map[string]interface{}); ok {
+			body = row
+		}
+	}
+	delete(body, "id")
+	normalizeSecurityBody(body)
+	return body, nil
+}
+
+func normalizeSecurityBody(v interface{}) {
+	switch x := v.(type) {
+	case map[string]interface{}:
+		for k, child := range x {
+			if (k == "custom" || k == "object") && emptyMap(child) {
+				x[k] = []interface{}{}
+				continue
+			}
+			normalizeSecurityBody(child)
+		}
+	case []interface{}:
+		for _, child := range x {
+			normalizeSecurityBody(child)
+		}
+	}
+}
+
+func emptyMap(v interface{}) bool {
+	m, ok := v.(map[string]interface{})
+	return ok && len(m) == 0
+}
+
+func configSetCmd(app *cliapp.Runtime, use, short, apiPath string, addFlags func(*cobra.Command), fieldMap map[string]string, addrFields map[string]string) *cobra.Command {
+	c := &cobra.Command{Use: use, Short: short}
+	if addFlags != nil {
+		addFlags(c)
+	}
+	for flagName := range addrFields {
+		if c.Flags().Lookup(flagName) == nil {
+			desc := flagDescs[flagName]
+			if desc == "" {
+				desc = "Comma-separated " + flagName + " values"
+			}
+			c.Flags().String(flagName, "", desc)
+		}
+	}
+	c.Flags().String("data", "{}", "JSON body")
+	c.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := app.RequireAuth(); err != nil {
+			return err
+		}
+		data, _ := cmd.Flags().GetString("data")
+		changes, err := cliapp.MergeDataWithFlags(data, cmd, fieldMap)
+		if err != nil {
+			return err
+		}
+		full, err := fullBodyFromGet(app, cliapp.APIBase+apiPath)
+		if err != nil {
+			return err
+		}
+		for k, v := range changes {
+			full[k] = v
+		}
+		applyAddrFields(full, cmd, addrFields)
+		raw, err := app.APIClient.Put(cliapp.APIBase+apiPath, full)
+		if err != nil {
+			return err
+		}
+		app.PrintRaw(raw)
+		return nil
+	}
+	return c
+}
+
+func macSetModeCmd(app *cliapp.Runtime) *cobra.Command {
+	c := dataCmdWithFlags(app, "set-mode", "Set MAC filter mode", func(c *cobra.Command) {
+		c.Flags().String("acl-mac", "", "MAC mode (0=blacklist, 1=whitelist)")
+	}, macModeFieldMap, func(body interface{}, id string) (json.RawMessage, error) {
+		return app.APIClient.Put(cliapp.APIBase+"/security/mac-mode", body)
+	})
+	cliapp.MarkFlagsRequired(c, "acl-mac")
+	origRunE := c.RunE
+	c.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := cliapp.RequireFlags(cmd, "acl-mac"); err != nil {
+			return err
+		}
+		return origRunE(cmd, args)
+	}
+	return c
+}
+
+func applyAddrFields(body map[string]interface{}, cmd *cobra.Command, addrFields map[string]string) {
+	for flagName, apiField := range addrFields {
+		f := cmd.Flags().Lookup(flagName)
+		if f == nil || !f.Changed {
+			continue
+		}
+		parts := strings.Split(f.Value.String(), ",")
+		custom := make([]interface{}, 0, len(parts))
+		for _, v := range parts {
+			v = strings.TrimSpace(v)
+			if v != "" {
+				custom = append(custom, v)
+			}
+		}
+		body[apiField] = map[string]interface{}{
+			"custom": custom,
+			"object": []interface{}{},
+		}
+	}
+}
+
 // addSemanticFlags registers a --<flag> string flag for every key in fieldMap,
 // skipping "enabled" (handled by AddEnabledFlag).
-func addSemanticFlags(cmd *cobra.Command, fieldMap map[string]string) {
+func addSemanticFlags(cmd *cobra.Command, fieldMap map[string]string, customFlagDescs map[string]string) {
 	for flagName, apiField := range fieldMap {
 		if flagName == "enabled" {
 			continue
 		}
 		desc := flagDescs[flagName]
+		if customDesc := customFlagDescs[flagName]; customDesc != "" {
+			desc = customDesc
+		}
 		if desc == "" {
 			desc = "Set " + apiField + " field"
 		}
@@ -572,7 +712,7 @@ func addSemanticFlags(cmd *cobra.Command, fieldMap map[string]string) {
 	}
 }
 
-func getByIDCmd(app *cliapp.Runtime, use, short, apiPath string) *cobra.Command {
+func getByIDCmd(app *cliapp.Runtime, use, short, apiPath string, defaultColumns []string) *cobra.Command {
 	return &cobra.Command{
 		Use:   use,
 		Short: short,
@@ -580,6 +720,9 @@ func getByIDCmd(app *cliapp.Runtime, use, short, apiPath string) *cobra.Command 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := app.RequireAuth(); err != nil {
 				return err
+			}
+			if len(defaultColumns) > 0 {
+				app.DefaultColumns = defaultColumns
 			}
 			raw, err := app.APIClient.Get(cliapp.APIBase+apiPath+args[0], nil)
 			if err != nil {

--- a/skills/security.md
+++ b/skills/security.md
@@ -5,90 +5,135 @@ description: iKuai security rules — ACL, MAC filtering, L7 app rules, URL filt
 
 # Security
 
+面向 Agent 的建议：
+
+- 优先使用 `--format json`，便于解析 `rowid`、`data`、`total`。
+- 删除命令使用 `--yes --format json`。
+- 创建/删除类闭环建议：`create -> list/get 确认存在 -> delete -> list/get 确认消失`。
+- 高风险全局配置建议：`get baseline -> --dry-run -> set -> get verify -> restore -> get verify`。
+- `--data` 仅作为 escape hatch；常规操作优先使用语义化 flags。
+
 ## ACL（访问控制）
 
 ```bash
-ikuai-cli security acl list
-ikuai-cli security acl get <ID>
-ikuai-cli security acl create --name "block_ssh" --action drop --protocol tcp --dst-port "22"
-ikuai-cli security acl toggle <ID> --enabled no
-ikuai-cli security acl delete <ID>
+ikuai-cli security acl list --format json
+ikuai-cli security acl get <ID> --format json
+ikuai-cli security acl create --name "block_ssh" --action drop --protocol tcp --direction forward --dst-port "22" --priority 30 --enabled no --format json
+ikuai-cli security acl update <ID> --name "block_ssh_u" --action drop --protocol tcp --direction forward --dst-port "2222" --priority 31 --enabled no --format json
+ikuai-cli security acl toggle <ID> --enabled yes --format json
+ikuai-cli security acl delete <ID> --yes --format json
 ```
 
-`--src-addr`, `--dst-addr`, `--src-port`, `--dst-port` 支持逗号分隔（addrFields）。
+`--src-addr`, `--dst-addr`, `--src-port`, `--dst-port` 支持逗号分隔。`--priority` 建议使用 10-50 范围。
 
 ## MAC 过滤
 
 ```bash
-ikuai-cli security mac get-mode
-ikuai-cli security mac set-mode --acl-mac 0
-# --data '{"acl_mac":0}' 也可用
-ikuai-cli security mac list
-ikuai-cli security mac create --name "allow1" --mac "00:11:22:33:44:55"
-ikuai-cli security mac toggle <ID> --enabled no
-ikuai-cli security mac delete <ID>
+ikuai-cli security mac get-mode --format json
+ikuai-cli security mac set-mode --acl-mac 0 --dry-run --format json
+ikuai-cli security mac set-mode --acl-mac 0 --format json
+ikuai-cli security mac list --format json
+ikuai-cli security mac get <ID> --format json
+ikuai-cli security mac create --name "allow1" --mac "00:11:22:33:44:55" --enabled no --format json
+ikuai-cli security mac update <ID> --name "allow1_u" --mac "00:11:22:33:44:55" --enabled no --format json
+ikuai-cli security mac toggle <ID> --enabled yes --format json
+ikuai-cli security mac delete <ID> --yes --format json
 ```
 
 ## L7 应用层规则
 
 ```bash
-ikuai-cli security l7 list
-ikuai-cli security l7 get <ID>
-ikuai-cli security l7 create --name "block_p2p" --action drop --app-proto "BT,eMule"
-ikuai-cli security l7 toggle <ID> --enabled no
-ikuai-cli security l7 delete <ID>
+ikuai-cli security l7 list --format json
+ikuai-cli security l7 get <ID> --format json
+ikuai-cli security l7 create --name "block_app" --action drop --app-proto "抖音短视频" --priority 30 --enabled no --format json
+ikuai-cli security l7 update <ID> --name "block_app_u" --action drop --app-proto "抖音短视频" --priority 31 --enabled no --format json
+ikuai-cli security l7 toggle <ID> --enabled yes --format json
+ikuai-cli security l7 delete <ID> --yes --format json
 ```
+
+`--priority` 建议使用 10-50 范围。
 
 ## URL 过滤
 
 ```bash
 # 黑名单
-ikuai-cli security url black list
-ikuai-cli security url black create --name "block_ads" --mode 0 --domain "ads.example.com"
-ikuai-cli security url black delete <ID>
+ikuai-cli security url black list --format json
+ikuai-cli security url black get <ID> --format json
+ikuai-cli security url black create --name "block_ads" --mode 0 --domain "ads.example.com" --enabled no --format json
+ikuai-cli security url black update <ID> --name "block_ads_u" --mode 0 --domain "ads.example.com" --enabled no --format json
+ikuai-cli security url black toggle <ID> --enabled yes --format json
+ikuai-cli security url black delete <ID> --yes --format json
 
 # 关键词
-ikuai-cli security url keywords list
-ikuai-cli security url keywords create --name "kw1" --mode exact --src-url "example.com" --ori-keyword "bad" --rep-keyword "good"
+ikuai-cli security url keywords list --format json
+ikuai-cli security url keywords create --name "kw1" --mode exact --src-url "example.com" --ori-keyword "bad" --rep-keyword "good" --hit-rate 1 --priority 10 --enabled no --format json
+ikuai-cli security url keywords update <ID> --name "kw1_u" --mode exact --src-url "example.com" --ori-keyword "bad" --rep-keyword "better" --hit-rate 1 --priority 11 --enabled no --format json
+ikuai-cli security url keywords toggle <ID> --enabled yes --format json
+ikuai-cli security url keywords delete <ID> --yes --format json
 
 # 重定向
-ikuai-cli security url redirect list
-ikuai-cli security url redirect create --name "redir1" --mode exact --src-url "old.com" --dst-url "new.com"
+ikuai-cli security url redirect list --format json
+ikuai-cli security url redirect create --name "redir1" --mode exact --src-url "old.com" --dst-url "192.0.2.10" --hit-rate 1 --priority 30 --enabled no --format json
+ikuai-cli security url redirect update <ID> --name "redir1_u" --mode exact --src-url "old.com" --dst-url "192.0.2.11" --hit-rate 1 --priority 31 --enabled no --format json
+ikuai-cli security url redirect toggle <ID> --enabled yes --format json
+ikuai-cli security url redirect delete <ID> --yes --format json
 
 # 替换
-ikuai-cli security url replace list
-ikuai-cli security url replace create --name "rep1" --mode exact --src-url "example.com" --param-keyword "track" --rep-keyword ""
+ikuai-cli security url replace list --format json
+ikuai-cli security url replace create --name "rep1" --mode exact --src-url "example.com" --param-keyword "track" --rep-keyword "clean" --hit-rate 1 --priority 30 --enabled no --format json
+ikuai-cli security url replace update <ID> --name "rep1_u" --mode exact --src-url "example.com" --param-keyword "track" --rep-keyword "clean2" --hit-rate 1 --priority 31 --enabled no --format json
+ikuai-cli security url replace toggle <ID> --enabled yes --format json
+ikuai-cli security url replace delete <ID> --yes --format json
 ```
+
+`url black --mode` 使用 `0/1`；`url keywords/redirect/replace --mode` 使用 `exact/vague`。`url keywords --priority` 建议 1-32；`url redirect/replace --priority` 建议 1-63。
 
 ## 域名黑名单
 
 ```bash
-ikuai-cli security domain-blacklist list
-ikuai-cli security domain-blacklist create --name "blocked" --domain-group "evil.com"
-ikuai-cli security domain-blacklist delete <ID>
+ikuai-cli security domain-blacklist list --format json
+ikuai-cli security domain-blacklist get <ID> --format json
+ikuai-cli security domain-blacklist create --name "blocked" --domain-group "evil_group" --enabled no --format json
+ikuai-cli security domain-blacklist update <ID> --name "blocked_u" --domain-group "evil_group" --enabled no --format json
+ikuai-cli security domain-blacklist toggle <ID> --enabled yes --format json
+ikuai-cli security domain-blacklist delete <ID> --yes --format json
 ```
 
 ## 连接数限制（Peerconn）
 
 ```bash
-ikuai-cli security peerconn list
-ikuai-cli security peerconn create --name "limit1" --limits 500 --protocol tcp --src-addr "192.168.9.0/24"
+ikuai-cli security peerconn list --format json
+ikuai-cli security peerconn get <ID> --format json
+ikuai-cli security peerconn create --name "limit1" --limits 500 --protocol tcp --src-addr "192.168.9.0/24" --dst-port "65000" --enabled no --format json
+ikuai-cli security peerconn update <ID> --name "limit1_u" --limits 501 --protocol tcp --src-addr "192.168.9.0/24" --dst-port "65001" --enabled no --format json
+ikuai-cli security peerconn toggle <ID> --enabled yes --format json
+ikuai-cli security peerconn delete <ID> --yes --format json
 ```
 
 ## 终端标注（Terminals）
 
 ```bash
-ikuai-cli security terminals list
-ikuai-cli security terminals create --name "printer" --mac "AA:BB:CC:DD:EE:FF"
+ikuai-cli security terminals list --format json
+ikuai-cli security terminals get <ID> --format json
+ikuai-cli security terminals create --name "printer" --mac "AA:BB:CC:DD:EE:FF" --format json
+ikuai-cli security terminals update <ID> --name "printer_u" --mac "AA:BB:CC:DD:EE:FF" --format json
+ikuai-cli security terminals delete <ID> --yes --format json
 ```
+
+`terminals` 没有 `toggle` 命令。
 
 ## 高级安全配置
 
 ```bash
-ikuai-cli security advanced-get
-ikuai-cli security advanced-set --data '{"noping_lan":0,"noping_wan":1,"notracert":0,"hijack_ping":0,"invalid":0,"dos_lan":1,"dos_lan_num":500,"tcp_mss":1,"tcp_mss_num":1400}'
-# 全量更新，需传所有必填字段；也支持 --noping-wan 等 flags 覆盖
-ikuai-cli security secondary-route-get
-ikuai-cli security secondary-route-set --data '{"nol2rt":0,"nol2rt_ip":{"custom":[],"object":[]},"ttl_num":1,"time":""}'
-# 全量更新；也支持 --nol2rt / --ttl-num flags
+ikuai-cli security advanced-get --format json
+ikuai-cli security advanced-set --noping-lan 1 --dry-run --format json
+ikuai-cli security advanced-set --noping-lan 1 --format json
+ikuai-cli security advanced-set --noping-lan 0 --format json
+
+ikuai-cli security secondary-route-get --format json
+ikuai-cli security secondary-route-set --ttl-num 21 --dry-run --format json
+ikuai-cli security secondary-route-set --ttl-num 21 --format json
+ikuai-cli security secondary-route-set --ttl-num 20 --format json
 ```
+
+`advanced-set` 和 `secondary-route-set` 会先读取当前配置，再用 flags 覆盖指定字段并提交完整 PUT body。回归或自动化执行时必须恢复 baseline。


### PR DESCRIPTION
## Summary
- align security command behavior with real-device regression findings
- add full-body update handling and missing security command coverage
- update security docs and help examples after regression

## Validation
- go test ./internal/cmd/security ./internal/cliapp
- go build -o /tmp/ikuai-cli ./cmd/ikuai-cli
- go test ./...
- security real-device regression: PASS=36 FAIL=0 BLOCKED=0