### PR TITLE
test: complete qos command regression

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -189,9 +189,14 @@ ikuai-cli routing stream l7 list
 ## QoS
 
 ```bash
-ikuai-cli qos ip list
-ikuai-cli qos ip create --name "Limit" --ip-addr 192.168.1.100 --upload 10M --download 50M
-ikuai-cli qos mac list
+ikuai-cli qos ip list --format json
+ikuai-cli qos ip create --name limit100 --ip-addr 192.168.1.100 --interface wan1 --upload 1000 --download 1000 --format json
+ikuai-cli qos ip update <ID> --name limit100u --upload 1200 --download 1300 --format json
+ikuai-cli qos ip toggle <ID> --enabled no --format json
+ikuai-cli qos ip delete <ID> --yes --format json
+ikuai-cli qos mac list --format json
+ikuai-cli qos mac create --name limitmac --mac-addr 00:11:22:33:44:55 --interface wan1 --upload 500 --download 500 --format json
+ikuai-cli qos mac delete <ID> --yes --format json
 ```
 
 ## Log

--- a/internal/cmd/qos/behavior_test.go
+++ b/internal/cmd/qos/behavior_test.go
@@ -85,7 +85,7 @@ func TestIPCreateSendsExpectedJSONBody(t *testing.T) {
 			}
 			// writeCmd merges createDefaults into the body, so we check key fields.
 			bs := string(body)
-			for _, want := range []string{`"tagname":"office-cap"`, `"upload":"20M"`, `"download":"20M"`, `"interface":"wan1"`} {
+			for _, want := range []string{`"tagname":"office-cap"`, `"upload":2000`, `"download":2000`, `"interface":"wan1"`} {
 				if !bytes.Contains(body, []byte(want)) {
 					t.Fatalf("body missing %s: %s", want, bs)
 				}
@@ -96,7 +96,7 @@ func TestIPCreateSendsExpectedJSONBody(t *testing.T) {
 	})
 
 	cmd := New(app)
-	cmd.SetArgs([]string{"ip", "create", "--name", "office-cap", "--interface", "wan1", "--upload", "20M", "--download", "20M"})
+	cmd.SetArgs([]string{"ip", "create", "--name", "office-cap", "--interface", "wan1", "--upload", "2000", "--download", "2000"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -105,6 +105,73 @@ func TestIPCreateSendsExpectedJSONBody(t *testing.T) {
 	want := "{\"message\":\"created\"}\n"
 	if got != want {
 		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestIPUpdateSendsFullBodyFromGet(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	var seenGet bool
+	var seenPut bool
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-qos"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.Method {
+			case http.MethodGet:
+				seenGet = true
+				if req.URL.String() != "https://router.local/api/v4.0/network/qos/ip/7" {
+					t.Fatalf("GET URL = %q, want %q", req.URL.String(), "https://router.local/api/v4.0/network/qos/ip/7")
+				}
+				return jsonResponse(`{"code":0,"data":{"id":7,"tagname":"old-qos","enabled":"yes","upload":100,"download":200,"type":0,"protocol":"any","comment":"","interface":"wan1","ip_addr":{"custom":["192.0.2.10"],"object":[]},"src_port":{"custom":[],"object":[]},"dst_port":{"custom":[],"object":[]},"attr":0}}`), nil
+			case http.MethodPut:
+				seenPut = true
+				if req.URL.String() != "https://router.local/api/v4.0/network/qos/ip/7" {
+					t.Fatalf("PUT URL = %q, want %q", req.URL.String(), "https://router.local/api/v4.0/network/qos/ip/7")
+				}
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("ReadAll() error = %v", err)
+				}
+				bs := string(body)
+				for _, want := range []string{
+					`"tagname":"new-qos"`,
+					`"enabled":"yes"`,
+					`"upload":100`,
+					`"download":300`,
+					`"interface":"wan1"`,
+					`"protocol":"any"`,
+					`"attr":0`,
+					`"src_port":{"custom":[],"object":[]}`,
+					`"dst_port":{"custom":[],"object":[]}`,
+					`"ip_addr":{"custom":["192.0.2.10"],"object":[]}`,
+				} {
+					if !bytes.Contains(body, []byte(want)) {
+						t.Fatalf("body missing %s: %s", want, bs)
+					}
+				}
+				for _, forbidden := range []string{`"id":`} {
+					if bytes.Contains(body, []byte(forbidden)) {
+						t.Fatalf("body contains %s: %s", forbidden, bs)
+					}
+				}
+				return jsonResponse(`{"code":0,"message":"updated","data":null}`), nil
+			default:
+				t.Fatalf("method = %q, want GET or PUT", req.Method)
+			}
+			return nil, nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"ip", "update", "7", "--name", "new-qos", "--download", "300"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !seenGet || !seenPut {
+		t.Fatalf("seenGet=%v seenPut=%v, want both true", seenGet, seenPut)
 	}
 }
 

--- a/internal/cmd/qos/command.go
+++ b/internal/cmd/qos/command.go
@@ -57,6 +57,8 @@ var qosMACAddrFields = map[string]string{
 var qosMACCreateDefaults = map[string]interface{}{
 	"enabled": "yes",
 	"comment": "",
+	"type":    0,
+	"ip_type": "4",
 	"time": map[string]interface{}{
 		"custom": []interface{}{
 			map[string]interface{}{
@@ -72,11 +74,11 @@ func addQoSIPFlags(cmd *cobra.Command) {
 	cmd.Flags().String("name", "", "Rule name (tagname)")
 	cmd.Flags().String("ip-addr", "", "IP address or range")
 	cmd.Flags().String("interface", "", "Network interface")
-	cmd.Flags().String("protocol", "", "Protocol (tcp/udp/all)")
+	cmd.Flags().String("protocol", "", "Protocol (any/tcp/udp/tcp+udp)")
 	cmd.Flags().String("src-port", "", "Source port")
 	cmd.Flags().String("dst-port", "", "Destination port")
-	cmd.Flags().String("upload", "", "Upload bandwidth limit")
-	cmd.Flags().String("download", "", "Download bandwidth limit")
+	cmd.Flags().String("upload", "", "Upload bandwidth limit in Kbps")
+	cmd.Flags().String("download", "", "Download bandwidth limit in Kbps")
 	cmd.Flags().String("comment", "", "Comment")
 	cliapp.AddEnabledFlag(cmd)
 }
@@ -85,8 +87,8 @@ func addQoSMACFlags(cmd *cobra.Command) {
 	cmd.Flags().String("name", "", "Rule name (tagname)")
 	cmd.Flags().String("mac-addr", "", "MAC address")
 	cmd.Flags().String("interface", "", "Network interface")
-	cmd.Flags().String("upload", "", "Upload bandwidth limit")
-	cmd.Flags().String("download", "", "Download bandwidth limit")
+	cmd.Flags().String("upload", "", "Upload bandwidth limit in Kbps")
+	cmd.Flags().String("download", "", "Download bandwidth limit in Kbps")
 	cmd.Flags().String("comment", "", "Comment")
 	cliapp.AddEnabledFlag(cmd)
 }
@@ -151,7 +153,7 @@ func qosGroup(app *cliapp.Runtime, name, apiPath string, addFlags func(*cobra.Co
 
 	createCmd := dataCommandImpl(app, "create", "Create a "+name+" QoS rule", false, addFlags, fieldMap, addrFields, defaults, func(body interface{}, id string) (json.RawMessage, error) {
 		return app.APIClient.Post(cliapp.APIBase+"/"+apiPath, body)
-	})
+	}, "")
 	if len(requiredCreateFlags) > 0 {
 		cliapp.MarkFlagsRequired(createCmd, requiredCreateFlags...)
 		origRunE := createCmd.RunE
@@ -164,11 +166,11 @@ func qosGroup(app *cliapp.Runtime, name, apiPath string, addFlags func(*cobra.Co
 	}
 	updateCmd := dataCommandImpl(app, "update ID", "Update a "+name+" QoS rule", true, addFlags, fieldMap, addrFields, nil, func(body interface{}, id string) (json.RawMessage, error) {
 		return app.APIClient.Put(cliapp.APIBase+"/"+apiPath+"/"+id, body)
-	})
+	}, apiPath)
 	toggleFieldMap := map[string]string{"enabled": "enabled"}
 	toggleCmd := dataCommandImpl(app, "toggle ID", "Enable/disable a "+name+" QoS rule", true, cliapp.AddEnabledFlag, toggleFieldMap, nil, nil, func(body interface{}, id string) (json.RawMessage, error) {
 		return app.APIClient.Patch(cliapp.APIBase+"/"+apiPath+"/"+id, body)
-	})
+	}, "")
 
 	deleteCmd := &cobra.Command{
 		Use:     "delete ID",
@@ -200,7 +202,7 @@ func qosGroup(app *cliapp.Runtime, name, apiPath string, addFlags func(*cobra.Co
 
 type callWithBody func(body interface{}, id string) (json.RawMessage, error)
 
-func dataCommandImpl(app *cliapp.Runtime, use, short string, withID bool, addFlags func(*cobra.Command), fieldMap map[string]string, addrFields map[string]string, defaults map[string]interface{}, fn callWithBody) *cobra.Command {
+func dataCommandImpl(app *cliapp.Runtime, use, short string, withID bool, addFlags func(*cobra.Command), fieldMap map[string]string, addrFields map[string]string, defaults map[string]interface{}, fn callWithBody, fullUpdatePath string) *cobra.Command {
 	c := &cobra.Command{
 		Use:   use,
 		Short: short,
@@ -248,6 +250,12 @@ func dataCommandImpl(app *cliapp.Runtime, use, short string, withID bool, addFla
 				"object": []interface{}{},
 			}
 		}
+		if withID && fullUpdatePath != "" {
+			body, err = qosFullUpdateBody(app, fullUpdatePath, args[0], body)
+			if err != nil {
+				return err
+			}
+		}
 		id := ""
 		if withID {
 			id = args[0]
@@ -267,4 +275,89 @@ func dataCommandImpl(app *cliapp.Runtime, use, short string, withID bool, addFla
 		cliapp.MarkFlagsRequired(c, "enabled")
 	}
 	return c
+}
+
+func qosFullUpdateBody(app *cliapp.Runtime, apiPath, id string, updates map[string]interface{}) (map[string]interface{}, error) {
+	readClient := app.APIClient
+	if app.APIClient.DryRun {
+		readClient = app.NewClient(app.Session.BaseURL, app.Session.Token)
+	}
+	raw, err := readClient.Get(cliapp.APIBase+"/"+apiPath+"/"+id, nil)
+	if err != nil {
+		return nil, err
+	}
+	current, err := qosInputFromGet(raw)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range updates {
+		current[k] = v
+	}
+	return current, nil
+}
+
+func qosInputFromGet(raw json.RawMessage) (map[string]interface{}, error) {
+	var value interface{}
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, err
+	}
+	body, ok := findQoSObject(value)
+	if !ok {
+		return nil, &cliapp.ValidationError{Message: "unexpected QoS get response"}
+	}
+	result := map[string]interface{}{}
+	for k, v := range body {
+		if k == "id" {
+			continue
+		}
+		result[k] = v
+	}
+	normalizeQoSBody(result)
+	return result, nil
+}
+
+func findQoSObject(value interface{}) (map[string]interface{}, bool) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		if _, ok := typed["tagname"]; ok {
+			return typed, true
+		}
+		for _, key := range []string{"data", "results"} {
+			if nested, ok := typed[key]; ok {
+				if found, ok := findQoSObject(nested); ok {
+					return found, true
+				}
+			}
+		}
+	case []interface{}:
+		if len(typed) == 0 {
+			return nil, false
+		}
+		return findQoSObject(typed[0])
+	}
+	return nil, false
+}
+
+func normalizeQoSBody(value interface{}) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		for k, child := range typed {
+			if (k == "custom" || k == "object") && emptyQoSMap(child) {
+				typed[k] = []interface{}{}
+				continue
+			}
+			normalizeQoSBody(child)
+		}
+	case []interface{}:
+		for _, child := range typed {
+			normalizeQoSBody(child)
+		}
+	}
+}
+
+func emptyQoSMap(value interface{}) bool {
+	if typed, ok := value.(map[string]interface{}); ok {
+		return len(typed) == 0
+	}
+	return false
 }

--- a/skills/qos.md
+++ b/skills/qos.md
@@ -8,22 +8,25 @@ description: iKuai QoS bandwidth control — IP-based and MAC-based bandwidth li
 ## IP 限速
 
 ```bash
-ikuai-cli qos ip list
-ikuai-cli qos ip create --name "limit_100m" --ip-addr "192.168.9.0/24" --upload 100 --download 100 --interface wan1
-ikuai-cli qos ip get <ID>
-ikuai-cli qos ip toggle <ID> --enabled no
-ikuai-cli qos ip delete <ID>
+ikuai-cli qos ip list --format json
+ikuai-cli qos ip create --name "limit100" --ip-addr "192.168.9.0/24" --upload 1000 --download 1000 --interface wan1 --format json
+ikuai-cli qos ip get <ID> --format json
+ikuai-cli qos ip update <ID> --name "limit100u" --upload 1200 --download 1300 --comment "updated" --format json
+ikuai-cli qos ip toggle <ID> --enabled no --format json
+ikuai-cli qos ip delete <ID> --yes --format json
 ```
 
-`--ip-addr` 支持逗号分隔多 IP（addrFields 模式）。
+`--upload` 和 `--download` 使用 Kbps 数值；`--ip-addr` 支持逗号分隔多 IP。
 
 ## MAC 限速
 
 ```bash
-ikuai-cli qos mac list
-ikuai-cli qos mac create --name "limit_mac" --mac-addr "00:11:22:33:44:55" --upload 50 --download 50 --interface wan1
-ikuai-cli qos mac toggle <ID> --enabled no
-ikuai-cli qos mac delete <ID>
+ikuai-cli qos mac list --format json
+ikuai-cli qos mac create --name "limitmac" --mac-addr "00:11:22:33:44:55" --upload 500 --download 500 --interface wan1 --format json
+ikuai-cli qos mac get <ID> --format json
+ikuai-cli qos mac update <ID> --name "limitmacu" --upload 800 --download 900 --comment "updated" --format json
+ikuai-cli qos mac toggle <ID> --enabled no --format json
+ikuai-cli qos mac delete <ID> --yes --format json
 ```
 
-`--mac-addr` 同样是 addrFields 模式。
+`--mac-addr` 支持逗号分隔多 MAC。


### PR DESCRIPTION
## Summary

- Complete qos full-device regression coverage for ip/mac CRUD, toggle, and TTY/JSON/YAML/wide/columns output.
- Fix qos update to read the current rule and send a complete PUT body, preserving device-required fields such as attr.
- Refresh qos usage docs with JSON-friendly examples and Kbps bandwidth units.