### PR TITLE
test: complete routing command regression

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -47,7 +47,6 @@ Common flags for `cpu`, `memory`, `disk`, `temp`, `terminals`, `connections`, `n
 ikuai-cli auth set-url https://192.168.1.1
 ikuai-cli auth set-token <your-api-token>
 ikuai-cli auth status
-ikuai-cli auth status --format json
 ikuai-cli auth clear
 ```
 
@@ -125,7 +124,7 @@ ikuai-cli network vlan create --name "IoT" --vlan-id 100 --interface lan1
 ## Users
 
 ```bash
-ikuai-cli users accounts list --format json
+ikuai-cli users accounts list
 ikuai-cli users accounts create --data '{"username":"guest","password":"guest123"}'
 ikuai-cli users online
 ikuai-cli users kick --data '{"id":1}'
@@ -181,22 +180,54 @@ ikuai-cli vpn wireguard peers
 
 ```bash
 ikuai-cli routing static list
+ikuai-cli routing static get <ID>
+ikuai-cli routing static create --name to_lan2 --dst-addr 10.10.10.0 --gateway 10.66.0.1 --netmask 255.255.255.0 --interface wan1
+ikuai-cli routing static update <ID> --name to_lan2_bak --priority 10
+ikuai-cli routing static toggle <ID> --enabled no
+ikuai-cli routing static delete <ID> --yes
 ikuai-cli routing stream domain list
+ikuai-cli routing stream domain get <ID>
+ikuai-cli routing stream domain create --name baidu --domain www.baidu.com,baidu.com --interface wan2
+ikuai-cli routing stream domain update <ID> --name baidu_wan1 --interface wan1
+ikuai-cli routing stream domain toggle <ID> --enabled no
+ikuai-cli routing stream domain delete <ID> --yes
 ikuai-cli routing stream five-tuple list
+ikuai-cli routing stream five-tuple get <ID>
+ikuai-cli routing stream five-tuple create --name web_wan2 --protocol tcp --dst-port 80,443 --interface wan2
+ikuai-cli routing stream five-tuple update <ID> --dst-port 8080,8443
+ikuai-cli routing stream five-tuple toggle <ID> --enabled no
+ikuai-cli routing stream five-tuple delete <ID> --yes
 ikuai-cli routing stream l7 list
+ikuai-cli routing stream l7 get <ID>
+ikuai-cli routing stream l7 create --name dns_wan2 --app-proto DNS --interface wan2
+ikuai-cli routing stream l7 update <ID> --name dns_wan1 --interface wan1
+ikuai-cli routing stream l7 toggle <ID> --enabled no
+ikuai-cli routing stream l7 delete <ID> --yes
+ikuai-cli routing stream load-balance list
+ikuai-cli routing stream load-balance get <ID>
+ikuai-cli routing stream load-balance create --name lb_wan1 --interface wan1 --mode 0 --weight 1 --isp-name all
+ikuai-cli routing stream load-balance update <ID> --weight 2
+ikuai-cli routing stream load-balance toggle <ID> --enabled no
+ikuai-cli routing stream load-balance delete <ID> --yes
+ikuai-cli routing stream updown list
+ikuai-cli routing stream updown get <ID>
+ikuai-cli routing stream updown create --name split --upiface wan1 --downiface wan2
+ikuai-cli routing stream updown update <ID> --protocol tcp --dst-port 80,443
+ikuai-cli routing stream updown toggle <ID> --enabled no
+ikuai-cli routing stream updown delete <ID> --yes
 ```
 
 ## QoS
 
 ```bash
-ikuai-cli qos ip list --format json
-ikuai-cli qos ip create --name limit100 --ip-addr 192.168.1.100 --interface wan1 --upload 1000 --download 1000 --format json
-ikuai-cli qos ip update <ID> --name limit100u --upload 1200 --download 1300 --format json
-ikuai-cli qos ip toggle <ID> --enabled no --format json
-ikuai-cli qos ip delete <ID> --yes --format json
-ikuai-cli qos mac list --format json
-ikuai-cli qos mac create --name limitmac --mac-addr 00:11:22:33:44:55 --interface wan1 --upload 500 --download 500 --format json
-ikuai-cli qos mac delete <ID> --yes --format json
+ikuai-cli qos ip list
+ikuai-cli qos ip create --name limit100 --ip-addr 192.168.1.100 --interface wan1 --upload 1000 --download 1000
+ikuai-cli qos ip update <ID> --name limit100u --upload 1200 --download 1300
+ikuai-cli qos ip toggle <ID> --enabled no
+ikuai-cli qos ip delete <ID> --yes
+ikuai-cli qos mac list
+ikuai-cli qos mac create --name limitmac --mac-addr 00:11:22:33:44:55 --interface wan1 --upload 500 --download 500
+ikuai-cli qos mac delete <ID> --yes
 ```
 
 ## Log
@@ -259,26 +290,25 @@ ikuai-cli auth-server set --data '{"enabled":true}'
 ## Objects
 
 ```bash
-ikuai-cli objects ip list --format json
-ikuai-cli objects ip create --name servers --value 192.168.1.10,192.168.1.11 --format json
-ikuai-cli objects ip get <ID> --format json
-ikuai-cli objects ip update <ID> --name servers_v2 --value 192.168.1.12 --format json
-ikuai-cli objects ip refs --group-name servers_v2 --format json
-ikuai-cli objects ip delete <ID> --yes --format json
-ikuai-cli objects ip6 list --format json
-ikuai-cli objects mac list --format json
-ikuai-cli objects port list --format json
-ikuai-cli objects proto list --format json
-ikuai-cli objects domain list --format json
-ikuai-cli objects time create --name office --type weekly --weekdays 12345 --start-time 09:00 --end-time 18:00 --format json
-ikuai-cli objects time list --format json
+ikuai-cli objects ip list
+ikuai-cli objects ip create --name servers --value 192.168.1.10,192.168.1.11
+ikuai-cli objects ip get <ID>
+ikuai-cli objects ip update <ID> --name servers_v2 --value 192.168.1.12
+ikuai-cli objects ip refs --group-name servers_v2
+ikuai-cli objects ip delete <ID> --yes
+ikuai-cli objects ip6 list
+ikuai-cli objects mac list
+ikuai-cli objects port list
+ikuai-cli objects proto list
+ikuai-cli objects domain list
+ikuai-cli objects time create --name office --type weekly --weekdays 12345 --start-time 09:00 --end-time 18:00
+ikuai-cli objects time list
 ```
 
 ## Other
 
 ```bash
 ikuai-cli version
-ikuai-cli version --format json
 ikuai-cli completion bash
 ikuai-cli completion zsh
 ikuai-cli completion fish

--- a/internal/cliapp/helpers.go
+++ b/internal/cliapp/helpers.go
@@ -78,6 +78,8 @@ var integerAPIFields = map[string]bool{
 	"mtu": true, "mru": true, "lcp_echo_interval": true,
 	"lcp_echo_failure": true, "maxconnect": true, "restart_timer": true,
 	"acl_mac": true, "mode": true,
+	"type": true, "iface_band": true, "dst_type": true,
+	"src_addr_inv": true, "dst_addr_inv": true,
 	"noping_lan": true, "noping_wan": true, "notracert": true,
 	"hijack_ping": true, "invalid": true, "dos_lan": true,
 	"dos_lan_num": true, "tcp_mss": true, "tcp_mss_num": true,

--- a/internal/cmd/routing/behavior_test.go
+++ b/internal/cmd/routing/behavior_test.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -106,6 +107,105 @@ func TestStreamFiveTupleCreateSendsExpectedJSONBody(t *testing.T) {
 	want := "{\"message\":\"created\"}\n"
 	if got != want {
 		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestStaticGetUsesYAMLEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-route"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			if req.URL.Path != "/api/v4.0/routing/static-routes/7" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/routing/static-routes/7")
+			}
+			return jsonResponse(`{"code":0,"message":"Success","results":{"total":1,"data":[{"id":7,"tagname":"route-test"}]}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"static", "get", "7"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, `"tagname":"route-test"`) {
+		t.Fatalf("output = %q, want route-test JSON", got)
+	}
+}
+
+func TestDomainUpdateReadsCurrentAndSendsFullJSONBody(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	requests := 0
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-route"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requests++
+			if req.URL.Path != "/api/v4.0/routing/domain-rules/7" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/routing/domain-rules/7")
+			}
+			switch requests {
+			case 1:
+				if req.Method != http.MethodGet {
+					t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+				}
+				return jsonResponse(`{"code":0,"message":"Success","data":{"id":7,"tagname":"old-domain","enabled":"yes","comment":"","interface":"wan1","prio":31,"domain":{"custom":["old.example"],"object":{}},"src_addr":{"custom":{},"object":{}},"time":{"custom":[{"type":"weekly","weekdays":"1234567","start_time":"00:00","end_time":"23:59","comment":""}],"object":{}}}}`), nil
+			case 2:
+				if req.Method != http.MethodPut {
+					t.Fatalf("method = %q, want %q", req.Method, http.MethodPut)
+				}
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("ReadAll() error = %v", err)
+				}
+				var got map[string]interface{}
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("json.Unmarshal() error = %v; body=%s", err, string(body))
+				}
+				if _, ok := got["id"]; ok {
+					t.Fatalf("body should not include id: %s", string(body))
+				}
+				for key, want := range map[string]interface{}{"tagname": "new-domain", "comment": "changed", "interface": "wan1"} {
+					if got[key] != want {
+						t.Fatalf("%s = %#v, want %#v; body=%s", key, got[key], want, string(body))
+					}
+				}
+				domain, ok := got["domain"].(map[string]interface{})
+				if !ok {
+					t.Fatalf("domain missing from body: %s", string(body))
+				}
+				custom, ok := domain["custom"].([]interface{})
+				if !ok || len(custom) != 1 || custom[0] != "old.example" {
+					t.Fatalf("domain.custom = %#v, want [old.example]", domain["custom"])
+				}
+				object, ok := domain["object"].([]interface{})
+				if !ok || len(object) != 0 {
+					t.Fatalf("domain.object = %#v, want empty array", domain["object"])
+				}
+				return jsonResponse(`{"code":0,"message":"success"}`), nil
+			default:
+				t.Fatalf("unexpected request %d", requests)
+			}
+			return nil, nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"stream", "domain", "update", "7", "--name", "new-domain", "--comment", "changed"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
 	}
 }
 

--- a/internal/cmd/routing/command.go
+++ b/internal/cmd/routing/command.go
@@ -19,14 +19,22 @@ var flagDescs = map[string]string{
 	// static / five-tuple shared
 	"dst-addr": "Destination address",
 	"gateway":  "Next-hop gateway IP",
+	"ip-type":  "IP type (4/6)",
 	"netmask":  "Subnet mask",
 	// stream domain
 	"domain": "Domain list (comma-separated)",
 	// stream five-tuple
-	"protocol": "Protocol (tcp/udp/any)",
-	"src-addr": "Source address (comma-separated)",
-	"src-port": "Source port (comma-separated)",
-	"dst-port": "Destination port (comma-separated)",
+	"area-code":    "Destination area code",
+	"dst-addr-inv": "Invert destination address match (0/1)",
+	"dst-port":     "Destination port (comma-separated)",
+	"dst-type":     "Destination type (0=address, 1=area)",
+	"iface-band":   "Bind interface (0/1)",
+	"nexthop":      "Next-hop gateway for LAN forwarding",
+	"protocol":     "Protocol (tcp/udp/any)",
+	"src-addr":     "Source address (comma-separated)",
+	"src-addr-inv": "Invert source address match (0/1)",
+	"src-port":     "Source port (comma-separated)",
+	"type":         "Forwarding type (0=WAN, 1=LAN)",
 	// stream l7
 	"app-proto": "App protocol (comma-separated)",
 	// stream load-balance
@@ -67,12 +75,20 @@ var (
 	}
 
 	fiveTupleFieldMap = map[string]string{
-		"name":      "tagname",
-		"interface": "interface",
-		"protocol":  "protocol",
-		"priority":  "prio",
-		"comment":   "comment",
-		"enabled":   "enabled",
+		"name":         "tagname",
+		"interface":    "interface",
+		"type":         "type",
+		"nexthop":      "nexthop",
+		"protocol":     "protocol",
+		"mode":         "mode",
+		"priority":     "prio",
+		"dst-type":     "dst_type",
+		"area-code":    "area_code",
+		"iface-band":   "iface_band",
+		"src-addr-inv": "src_addr_inv",
+		"dst-addr-inv": "dst_addr_inv",
+		"comment":      "comment",
+		"enabled":      "enabled",
 	}
 	fiveTupleAddrFields = map[string]string{
 		"src-addr": "src_addr",
@@ -103,11 +119,13 @@ var (
 	}
 
 	l7FieldMap = map[string]string{
-		"name":      "tagname",
-		"interface": "interface",
-		"priority":  "prio",
-		"comment":   "comment",
-		"enabled":   "enabled",
+		"name":       "tagname",
+		"interface":  "interface",
+		"mode":       "mode",
+		"priority":   "prio",
+		"iface-band": "iface_band",
+		"comment":    "comment",
+		"enabled":    "enabled",
 	}
 	l7AddrFields = map[string]string{
 		"app-proto": "app_proto",
@@ -132,6 +150,7 @@ var (
 	loadBalanceFieldMap = map[string]string{
 		"name":      "tagname",
 		"interface": "interface",
+		"mode":      "mode",
 		"weight":    "weight",
 		"isp-name":  "isp_name",
 		"comment":   "comment",
@@ -228,6 +247,7 @@ func staticGroup(app *cliapp.Runtime) *cobra.Command {
 		"interface": "interface",
 		"dst-addr":  "dst_addr",
 		"gateway":   "gateway",
+		"ip-type":   "ip_type",
 		"netmask":   "netmask",
 		"priority":  "prio",
 		"comment":   "comment",
@@ -261,7 +281,7 @@ func staticGroup(app *cliapp.Runtime) *cobra.Command {
 	}
 	cliapp.AddListFlags(listCmd)
 
-	createCmd := writeCmd(app, "create", "Create a static route", false, staticFieldMap, nil, staticDefaults,
+	createCmd := writeCmd(app, "create", "Create a static route", false, staticFieldMap, nil, staticDefaults, "",
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/routing/static-routes", body)
 		})
@@ -275,7 +295,8 @@ func staticGroup(app *cliapp.Runtime) *cobra.Command {
 			return origRunE(cmd, args)
 		}
 	}
-	updateCmd := writeCmd(app, "update ID", "Update a static route", true, staticFieldMap, nil, nil,
+	getCmd := getByIDCmd(app, "get ID", "Get a static route", "/routing/static-routes/")
+	updateCmd := writeCmd(app, "update ID", "Update a static route", true, staticFieldMap, nil, nil, "routing/static-routes",
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Put(cliapp.APIBase+"/routing/static-routes/"+id, body)
 		})
@@ -283,9 +304,10 @@ func staticGroup(app *cliapp.Runtime) *cobra.Command {
 	toggleFieldMap := map[string]string{"enabled": "enabled"}
 	group.AddCommand(
 		listCmd,
+		getCmd,
 		createCmd,
 		updateCmd,
-		writeCmd(app, "toggle ID", "Enable/disable a static route", true, toggleFieldMap, nil, nil,
+		writeCmd(app, "toggle ID", "Enable/disable a static route", true, toggleFieldMap, nil, nil, "",
 			func(body interface{}, id string) (json.RawMessage, error) {
 				return app.APIClient.Patch(cliapp.APIBase+"/routing/static-routes/"+id, body)
 			}),
@@ -327,7 +349,7 @@ func ruleGroup(app *cliapp.Runtime, use, short, apiPath string, opts ruleGroupOp
 	}
 	cliapp.AddListFlags(listCmd)
 
-	createCmd := writeCmd(app, "create", "Create a "+use+" rule", false, opts.fieldMap, opts.addrFields, opts.createDefaults,
+	createCmd := writeCmd(app, "create", "Create a "+use+" rule", false, opts.fieldMap, opts.addrFields, opts.createDefaults, "",
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/"+apiPath, body)
 		})
@@ -341,24 +363,45 @@ func ruleGroup(app *cliapp.Runtime, use, short, apiPath string, opts ruleGroupOp
 			return origRunE(cmd, args)
 		}
 	}
-	updateCmd := writeCmd(app, "update ID", "Update a "+use+" rule", true, opts.fieldMap, opts.addrFields, nil,
+	getCmd := getByIDCmd(app, "get ID", "Get a "+use+" rule", "/"+apiPath+"/")
+	updateCmd := writeCmd(app, "update ID", "Update a "+use+" rule", true, opts.fieldMap, opts.addrFields, nil, apiPath,
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Put(cliapp.APIBase+"/"+apiPath+"/"+id, body)
 		})
 	toggleFieldMap := map[string]string{"enabled": "enabled"}
-	toggleCmd := writeCmd(app, "toggle ID", "Enable/disable a "+use+" rule", true, toggleFieldMap, nil, nil,
+	toggleCmd := writeCmd(app, "toggle ID", "Enable/disable a "+use+" rule", true, toggleFieldMap, nil, nil, "",
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Patch(cliapp.APIBase+"/"+apiPath+"/"+id, body)
 		})
 
 	grp.AddCommand(
 		listCmd,
+		getCmd,
 		createCmd,
 		updateCmd,
 		toggleCmd,
 		deleteByIDCmd(app, "delete ID", "Delete a "+use+" rule", "/"+apiPath+"/"),
 	)
 	return grp
+}
+
+func getByIDCmd(app *cliapp.Runtime, use, short, apiPath string) *cobra.Command {
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			raw, err := app.APIClient.Get(cliapp.APIBase+apiPath+args[0], nil)
+			if err != nil {
+				return err
+			}
+			app.PrintRaw(raw)
+			return nil
+		},
+	}
 }
 
 func deleteByIDCmd(app *cliapp.Runtime, use, short, apiPath string) *cobra.Command {
@@ -394,7 +437,7 @@ type callWithBody func(body interface{}, id string) (json.RawMessage, error)
 
 // writeCmd builds a create/update/toggle command with semantic flags, addrFields, and defaults.
 // --data is kept as escape hatch for complex cases.
-func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[string]string, addrFields map[string]string, defaults map[string]interface{}, fn callWithBody) *cobra.Command {
+func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[string]string, addrFields map[string]string, defaults map[string]interface{}, fullUpdatePath string, fn callWithBody) *cobra.Command {
 	c := &cobra.Command{Use: use, Short: short}
 	if use == "create" {
 		c.Aliases = []string{"new"}
@@ -467,6 +510,12 @@ func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[
 				"object": []interface{}{},
 			}
 		}
+		if withID && fullUpdatePath != "" {
+			body, err = fullUpdateBody(app, fullUpdatePath, args[0], body)
+			if err != nil {
+				return err
+			}
+		}
 		id := ""
 		if withID {
 			id = args[0]
@@ -479,4 +528,89 @@ func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[
 		return nil
 	}
 	return c
+}
+
+func fullUpdateBody(app *cliapp.Runtime, apiPath, id string, updates map[string]interface{}) (map[string]interface{}, error) {
+	readClient := app.APIClient
+	if app.APIClient.DryRun {
+		readClient = app.NewClient(app.Session.BaseURL, app.Session.Token)
+	}
+	raw, err := readClient.Get(cliapp.APIBase+"/"+apiPath+"/"+id, nil)
+	if err != nil {
+		return nil, err
+	}
+	current, err := inputBodyFromGet(raw)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range updates {
+		current[k] = v
+	}
+	return current, nil
+}
+
+func inputBodyFromGet(raw json.RawMessage) (map[string]interface{}, error) {
+	var value interface{}
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, err
+	}
+	body, ok := findRuleObject(value)
+	if !ok {
+		return nil, &cliapp.ValidationError{Message: "unexpected routing get response"}
+	}
+	result := map[string]interface{}{}
+	for k, v := range body {
+		if k == "id" || strings.HasSuffix(k, "_int") {
+			continue
+		}
+		result[k] = v
+	}
+	normalizeInputBody(result)
+	return result, nil
+}
+
+func findRuleObject(value interface{}) (map[string]interface{}, bool) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		if _, ok := typed["tagname"]; ok {
+			return typed, true
+		}
+		for _, key := range []string{"data", "results"} {
+			if nested, ok := typed[key]; ok {
+				if found, ok := findRuleObject(nested); ok {
+					return found, true
+				}
+			}
+		}
+	case []interface{}:
+		if len(typed) == 0 {
+			return nil, false
+		}
+		return findRuleObject(typed[0])
+	}
+	return nil, false
+}
+
+func normalizeInputBody(value interface{}) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		for k, child := range typed {
+			if (k == "custom" || k == "object") && emptyMap(child) {
+				typed[k] = []interface{}{}
+				continue
+			}
+			normalizeInputBody(child)
+		}
+	case []interface{}:
+		for _, child := range typed {
+			normalizeInputBody(child)
+		}
+	}
+}
+
+func emptyMap(value interface{}) bool {
+	if typed, ok := value.(map[string]interface{}); ok {
+		return len(typed) == 0
+	}
+	return false
 }

--- a/skills/routing.md
+++ b/skills/routing.md
@@ -8,10 +8,12 @@ description: iKuai routing — static routes, traffic shunting (domain, five-tup
 ## 静态路由
 
 ```bash
-ikuai-cli routing static list
-ikuai-cli routing static create --name "to_lan2" --dst-addr "10.10.10.0" --gateway "10.66.0.1" --netmask "255.255.255.0" --interface wan1
-ikuai-cli routing static toggle <ID> --enabled no
-ikuai-cli routing static delete <ID>
+ikuai-cli routing static list --format json
+ikuai-cli routing static get <ID> --format json
+ikuai-cli routing static create --name "to_lan2" --dst-addr "10.10.10.0" --gateway "10.66.0.1" --netmask "255.255.255.0" --interface wan1 --format json
+ikuai-cli routing static update <ID> --name "to_lan2_bak" --priority 10 --format json
+ikuai-cli routing static toggle <ID> --enabled no --format json
+ikuai-cli routing static delete <ID> --yes --format json
 ```
 
 ## 分流规则（stream）
@@ -20,34 +22,52 @@ ikuai-cli routing static delete <ID>
 
 ### 域名分流
 ```bash
-ikuai-cli routing stream domain list
-ikuai-cli routing stream domain create --name "baidu" --domain "www.baidu.com,baidu.com" --interface wan2
-ikuai-cli routing stream domain toggle <ID> --enabled no
-ikuai-cli routing stream domain delete <ID>
+ikuai-cli routing stream domain list --format json
+ikuai-cli routing stream domain get <ID> --format json
+ikuai-cli routing stream domain create --name "baidu" --domain "www.baidu.com,baidu.com" --interface wan2 --format json
+ikuai-cli routing stream domain update <ID> --name "baidu_wan1" --interface wan1 --format json
+ikuai-cli routing stream domain toggle <ID> --enabled no --format json
+ikuai-cli routing stream domain delete <ID> --yes --format json
 ```
 
 ### 五元组分流
 ```bash
-ikuai-cli routing stream five-tuple list
-ikuai-cli routing stream five-tuple create --name "web_wan2" --protocol tcp --dst-port "80,443" --interface wan2
+ikuai-cli routing stream five-tuple list --format json
+ikuai-cli routing stream five-tuple get <ID> --format json
+ikuai-cli routing stream five-tuple create --name "web_wan2" --protocol tcp --dst-port "80,443" --interface wan2 --format json
+ikuai-cli routing stream five-tuple update <ID> --dst-port "8080,8443" --format json
+ikuai-cli routing stream five-tuple toggle <ID> --enabled no --format json
+ikuai-cli routing stream five-tuple delete <ID> --yes --format json
 ```
 
 ### L7 协议分流
 ```bash
-ikuai-cli routing stream l7 list
-ikuai-cli routing stream l7 create --name "dns_wan2" --app-proto "DNS" --interface wan2
+ikuai-cli routing stream l7 list --format json
+ikuai-cli routing stream l7 get <ID> --format json
+ikuai-cli routing stream l7 create --name "dns_wan2" --app-proto "DNS" --interface wan2 --format json
+ikuai-cli routing stream l7 update <ID> --name "dns_wan1" --interface wan1 --format json
+ikuai-cli routing stream l7 toggle <ID> --enabled no --format json
+ikuai-cli routing stream l7 delete <ID> --yes --format json
 ```
 
 ### 负载均衡
 ```bash
-ikuai-cli routing stream load-balance list
-ikuai-cli routing stream load-balance create --name "lb_wan1" --interface wan1
+ikuai-cli routing stream load-balance list --format json
+ikuai-cli routing stream load-balance get <ID> --format json
+ikuai-cli routing stream load-balance create --name "lb_wan1" --interface wan1 --mode 0 --weight 1 --isp-name all --format json
+ikuai-cli routing stream load-balance update <ID> --weight 2 --format json
+ikuai-cli routing stream load-balance toggle <ID> --enabled no --format json
+ikuai-cli routing stream load-balance delete <ID> --yes --format json
 ```
 
 ### 上下行分离
 ```bash
-ikuai-cli routing stream updown list
-ikuai-cli routing stream updown create --name "split" --upiface wan1 --downiface wan2
+ikuai-cli routing stream updown list --format json
+ikuai-cli routing stream updown get <ID> --format json
+ikuai-cli routing stream updown create --name "split" --upiface wan1 --downiface wan2 --format json
+ikuai-cli routing stream updown update <ID> --protocol tcp --dst-port "80,443" --format json
+ikuai-cli routing stream updown toggle <ID> --enabled no --format json
+ikuai-cli routing stream updown delete <ID> --yes --format json
 ```
 
-所有 stream 子命令支持 `--src-addr`、`--dst-addr` 等 addrFields。
+常用对象字段使用逗号分隔，例如 `--src-addr "192.168.1.10,192.168.1.11"`、`--dst-port "80,443"`、`--app-proto "DNS,HTTP"`。


### PR DESCRIPTION
## Summary

- Complete routing command regression fixes by adding YAML-defined get commands and full-body PUT update handling.
- Expand routing semantic flags and integer coercion for routing API fields.
- Update routing usage docs and CLI reference examples after regression coverage.
- Add routing behavior tests for get endpoints and full update body construction.