### PR TITLE
test: complete vpn command regression

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -167,13 +167,32 @@ ikuai-cli security secondary-route-get
 ```bash
 ikuai-cli vpn pptp get
 ikuai-cli vpn pptp clients
+ikuai-cli vpn pptp client-create --name pptpoffice --server vpn.example.com --username user1 --password 123456 --interface auto --enabled no
+ikuai-cli vpn pptp client-get <ID>
+ikuai-cli vpn pptp client-update <ID> --comment updated
+ikuai-cli vpn pptp client-toggle <ID> --enabled no
+ikuai-cli vpn pptp client-delete <ID> --yes
 ikuai-cli vpn l2tp get
 ikuai-cli vpn l2tp clients
 ikuai-cli vpn openvpn get
+ikuai-cli vpn openvpn client-create --name ovpnoffice --remote-addr vpn.example.com --username user1 --password 123456 --ca "<CA证书>" --interface auto --enabled no
 ikuai-cli vpn ikev2 get
+ikuai-cli vpn ikev2 client-create --name ikedoffice --remote-addr vpn.example.com --interface auto --left-id localid --username user1 --password 123456 --enabled no
 ikuai-cli vpn ipsec clients
+ikuai-cli vpn ipsec client-create --name ipsecsite --remote-addr 10.0.0.1 --interface wan1 --left-subnet 192.168.1.0/24 --right-subnet 192.168.2.0/24 --secret psk123 --enabled no
+ikuai-cli vpn ipsec client-get <ID>
+ikuai-cli vpn ipsec client-update <ID> --comment updated
+ikuai-cli vpn ipsec client-toggle <ID> --enabled no
+ikuai-cli vpn ipsec client-delete <ID> --yes
 ikuai-cli vpn wireguard list
-ikuai-cli vpn wireguard peers
+ikuai-cli vpn wireguard create --name wgsite --address 10.9.0.1/24 --interface auto --private-key "<base64>" --public-key "<base64>" --enabled no
+ikuai-cli vpn wireguard update <ID> --interface auto --port 5001
+ikuai-cli vpn wireguard peers <ID>
+ikuai-cli vpn wireguard peer-create <ID> --public-key "<base64>" --allow-ips 10.9.0.2/32 --interface wgsite --enabled no
+ikuai-cli vpn wireguard peer-get <ID> <PEER_ID>
+ikuai-cli vpn wireguard peer-update <ID> <PEER_ID> --interface wgsite --comment updated
+ikuai-cli vpn wireguard peer-toggle <ID> <PEER_ID> --enabled no
+ikuai-cli vpn wireguard peer-delete <ID> <PEER_ID> --yes
 ```
 
 ## Routing

--- a/internal/cliapp/helpers.go
+++ b/internal/cliapp/helpers.go
@@ -66,7 +66,11 @@ func GetListParams(cmd *cobra.Command) (page, pageSize int, filter, order, order
 // to look numeric (e.g. SNMP community "161", VLAN name "0010").
 var integerAPIFields = map[string]bool{
 	"sshd_port": true, "http_port": true, "https_port": true,
-	"prio": true, "priority": true,
+	"server_port": true, "open_mppe": true, "force_ipsec": true,
+	"local_listenport": true, "endpoint_port": true, "method": true,
+	"ikelifetime": true, "lifetime": true, "dpddelay": true, "dpdtimeout": true,
+	"keepalive": true,
+	"prio":      true, "priority": true,
 	"syn_recv_timeout": true, "established_timeout": true,
 	"upload": true, "download": true,
 	"ftp_ports": true, "sip_ports": true, "tftp_ports": true,

--- a/internal/cmd/vpn/command.go
+++ b/internal/cmd/vpn/command.go
@@ -108,6 +108,23 @@ var (
 		"ca":                "",
 	}
 
+	pptpClientUpdateInputFields = []string{
+		"id", "enabled", "name", "comment", "server", "server_port", "username", "passwd",
+		"interface", "mtu", "mru", "check_link_mode", "check_link_host", "timing_rst_switch",
+		"timing_rst_week", "timing_rst_time", "cycle_rst_time",
+	}
+	l2tpClientUpdateInputFields = []string{
+		"id", "enabled", "name", "comment", "server", "server_port", "username", "passwd",
+		"ipsec_secret", "interface", "leftid", "rightid", "mtu", "mru", "check_link_mode",
+		"check_link_host", "timing_rst_switch", "timing_rst_week", "timing_rst_time", "cycle_rst_time",
+	}
+	openvpnClientUpdateInputFields = []string{
+		"id", "enabled", "name", "comment", "remote_addr", "remote_port", "method", "username",
+		"password", "interface", "proto", "dev_type", "cipher", "tls_auth", "ca", "cert", "key",
+		"accept_push_route", "route", "comp_lzo", "tun_mtu", "check_link_mode", "check_link_host",
+		"timing_rst_switch", "timing_rst_week", "timing_rst_time", "extra_config",
+	}
+
 	// IKEv2 client
 	ikev2ClientFieldMap = map[string]string{
 		"name":        "name",
@@ -128,6 +145,10 @@ var (
 		"authby":          "mschapv2",
 		"check_link_mode": 3,
 		"check_link_host": "www.baidu.com",
+	}
+	ikev2ClientUpdateInputFields = []string{
+		"id", "enabled", "name", "comment", "remote_addr", "interface", "authby", "secret",
+		"leftid", "rightid", "username", "passwd", "check_link_mode", "check_link_host",
 	}
 
 	// IPSec client
@@ -157,6 +178,13 @@ var (
 		"esp_auth":    "sha256",
 		"aggressive":  "0",
 	}
+	ipsecClientUpdateInputFields = []string{
+		"id", "name", "comment", "remote_addr", "authby", "leftsubnet", "rightsubnet",
+		"interface", "enabled", "keyexchange", "aggressive", "ikelifetime", "ike_enc",
+		"ike_auth", "ike_dh", "secret", "leftid", "rightid", "privatekey", "leftcert",
+		"rightcert", "lifetime", "esp_enc", "esp_auth", "dpdaction", "dpddelay",
+		"dpdtimeout", "compress",
+	}
 
 	// WireGuard tunnel
 	wireguardFieldMap = map[string]string{
@@ -164,7 +192,6 @@ var (
 		"interface": "interface",
 		"address":   "local_address",
 		"port":      "local_listenport",
-		"comment":   "comment",
 		"enabled":   "enabled",
 	}
 	wireguardDefaults = map[string]interface{}{
@@ -172,7 +199,10 @@ var (
 		"interface":        "auto",
 		"local_listenport": 5000,
 		"mtu":              1420,
-		"keepalive":        0,
+	}
+	wireguardInputFields = []string{
+		"enabled", "name", "interface", "local_privatekey", "local_publickey", "local_address",
+		"local_listenport", "mtu",
 	}
 
 	// WireGuard peer
@@ -190,6 +220,10 @@ var (
 		"comment":   "",
 		"keepalive": 0,
 	}
+	wireguardPeerInputFields = []string{
+		"enabled", "comment", "interface", "peer_publickey", "presharedkey", "allowips",
+		"endpoint", "endpoint_port", "keepalive",
+	}
 
 	// --- VPN server field maps ---
 
@@ -203,6 +237,9 @@ var (
 		"open-mppe":   "open_mppe",
 		"mtu":         "mtu",
 		"mru":         "mru",
+	}
+	pptpServerInputFields = []string{
+		"enabled", "dns1", "dns2", "addr_pool", "open_mppe", "server_ip", "server_port", "mtu", "mru",
 	}
 
 	l2tpServerFieldMap = map[string]string{
@@ -219,24 +256,59 @@ var (
 		"rightid":      "rightid",
 		"force-ipsec":  "force_ipsec",
 	}
+	l2tpServerInputFields = []string{
+		"enabled", "server_ip", "server_port", "addr_pool", "dns1", "dns2", "mtu", "mru",
+		"ipsec_secret", "leftid", "rightid", "force_ipsec",
+	}
 
 	openvpnServerFieldMap = map[string]string{
-		"enabled":     "enabled",
-		"server-ip":   "server_ip",
-		"server-port": "server_port",
-		"addr-pool":   "addr_pool",
-		"dns1":        "dns1",
-		"dns2":        "dns2",
-		"proto":       "proto",
-		"mtu":         "mtu",
+		"enabled":            "enabled",
+		"proto":              "proto",
+		"port":               "port",
+		"server-port":        "port",
+		"subnet":             "subnet",
+		"mask":               "mask",
+		"tun-mtu":            "tun_mtu",
+		"mtu":                "tun_mtu",
+		"cipher":             "cipher",
+		"comp-lzo":           "comp_lzo",
+		"dev-type":           "dev_type",
+		"topology":           "topology",
+		"method":             "method",
+		"tls-auth":           "tls_auth",
+		"ca":                 "ca",
+		"cert":               "cert",
+		"key":                "key",
+		"push-gateway":       "push_gateway",
+		"push-route":         "push_route",
+		"push-route-comment": "push_route_comment",
+		"push-dns":           "push_dns",
+		"extra-config":       "extra_config",
+	}
+	openvpnServerInputFields = []string{
+		"enabled", "proto", "port", "subnet", "mask", "tun_mtu", "cipher", "comp_lzo",
+		"dev_type", "topology", "method", "tls_auth", "ca", "cert", "key", "push_gateway",
+		"push_route", "push_route_comment", "push_dns", "extra_config",
 	}
 
 	ikev2ServerFieldMap = map[string]string{
-		"enabled":   "enabled",
-		"server-ip": "server_ip",
-		"addr-pool": "addr_pool",
-		"dns1":      "dns1",
-		"dns2":      "dns2",
+		"enabled":     "enabled",
+		"authby":      "authby",
+		"addrpool":    "addrpool",
+		"addr-pool":   "addrpool",
+		"secret":      "secret",
+		"leftid":      "leftid",
+		"rightid":     "rightid",
+		"dns1":        "dns1",
+		"dns2":        "dns2",
+		"share-deny":  "share_deny",
+		"mtu":         "mtu",
+		"private-key": "privatekey",
+		"left-cert":   "leftcert",
+	}
+	ikev2ServerInputFields = []string{
+		"id", "enabled", "authby", "addrpool", "secret", "leftid", "rightid", "dns1",
+		"dns2", "share_deny", "mtu", "privatekey", "leftcert", "aggressive", "keyexchange", "name",
 	}
 )
 
@@ -253,23 +325,23 @@ func New(app *cliapp.Runtime) *cobra.Command {
 
 	vpnCmd.AddCommand(vpnServerGroup(app, "pptp", "vpn/pptp", pptpClientFieldMap, pptpClientDefaults,
 		[]string{"id", "name", "server", "username", "interface", "enabled"}, pptpServerFieldMap,
-		[]string{"name", "server", "username", "password", "interface"}))
+		pptpServerInputFields, pptpClientUpdateInputFields, []string{"name", "server", "username", "password", "interface"}))
 	vpnCmd.AddCommand(vpnServerGroup(app, "l2tp", "vpn/l2tp", l2tpClientFieldMap, l2tpClientDefaults,
 		[]string{"id", "name", "server", "username", "interface", "enabled"}, l2tpServerFieldMap,
-		[]string{"name", "server", "username", "password", "interface"}))
+		l2tpServerInputFields, l2tpClientUpdateInputFields, []string{"name", "server", "username", "password", "interface"}))
 	vpnCmd.AddCommand(vpnServerGroup(app, "openvpn", "vpn/openvpn", openvpnClientFieldMap, openvpnClientDefaults,
 		[]string{"id", "name", "remote_addr", "remote_port", "proto", "interface", "enabled"}, openvpnServerFieldMap,
-		[]string{"name", "remote-addr", "interface"}))
+		openvpnServerInputFields, openvpnClientUpdateInputFields, []string{"name", "remote-addr", "interface", "username", "password", "ca"}))
 	vpnCmd.AddCommand(vpnServerGroup(app, "ikev2", "vpn/ikev2", ikev2ClientFieldMap, ikev2ClientDefaults,
 		[]string{"id", "name", "remote_addr", "interface", "authby", "enabled"}, ikev2ServerFieldMap,
-		[]string{"name", "remote-addr", "interface", "left-id"}))
+		ikev2ServerInputFields, ikev2ClientUpdateInputFields, []string{"name", "remote-addr", "interface", "left-id"}))
 	vpnCmd.AddCommand(ipsecGroup(app))
 	vpnCmd.AddCommand(wireguardGroup(app))
 
 	return vpnCmd
 }
 
-func vpnServerGroup(app *cliapp.Runtime, name, apiPath string, clientFieldMap map[string]string, clientDefaults map[string]interface{}, defaultColumns []string, serverFieldMap map[string]string, requiredCreateFlags []string) *cobra.Command {
+func vpnServerGroup(app *cliapp.Runtime, name, apiPath string, clientFieldMap map[string]string, clientDefaults map[string]interface{}, defaultColumns []string, serverFieldMap map[string]string, serverInputFields []string, clientUpdateInputFields []string, requiredCreateFlags []string) *cobra.Command {
 	grp := &cobra.Command{Use: name, Short: name + " VPN"}
 
 	getCmd := &cobra.Command{
@@ -292,9 +364,7 @@ func vpnServerGroup(app *cliapp.Runtime, name, apiPath string, clientFieldMap ma
 		for flagName := range serverFieldMap {
 			c.Flags().String(flagName, "", flagName)
 		}
-	}, serverFieldMap, func(body interface{}, id string) (json.RawMessage, error) {
-		return app.APIClient.Put(cliapp.APIBase+"/"+apiPath+"/services", body)
-	})
+	}, serverFieldMap, serverInputFields, cliapp.APIBase+"/"+apiPath+"/services")
 
 	clientsCmd := &cobra.Command{
 		Use:   "clients",
@@ -332,13 +402,16 @@ func vpnServerGroup(app *cliapp.Runtime, name, apiPath string, clientFieldMap ma
 			return origRunE(cmd, args)
 		}
 	}
-	clientUpdateCmd := writeCmd(app, "client-update ID", "Update a "+name+" client", true, clientFieldMap, nil, nil,
+	clientGetCmd := getByIDCmd(app, "client-get ID", "Get a "+name+" client", "/"+apiPath+"/clients/")
+	clientUpdateCmd := updateByIDCmd(app, "client-update ID", "Update a "+name+" client", clientFieldMap, clientUpdateInputFields, cliapp.APIBase+"/"+apiPath+"/clients/")
+	clientToggleCmd := writeCmd(app, "client-toggle ID", "Enable/disable a "+name+" client", true, map[string]string{"enabled": "enabled"}, nil, nil,
 		func(body interface{}, id string) (json.RawMessage, error) {
-			return app.APIClient.Put(cliapp.APIBase+"/"+apiPath+"/clients/"+id, body)
+			return app.APIClient.Patch(cliapp.APIBase+"/"+apiPath+"/clients/"+id, body)
 		})
+	clientDeleteCmd := deleteByIDCmd(app, "client-delete ID", "Delete a "+name+" client", "/"+apiPath+"/clients/")
 	kickCmd := deleteByIDCmd(app, "kick ID", "Kick / delete a "+name+" client", "/"+apiPath+"/clients/")
 
-	grp.AddCommand(getCmd, setCmd, clientsCmd, clientCreateCmd, clientUpdateCmd, kickCmd)
+	grp.AddCommand(getCmd, setCmd, clientsCmd, clientGetCmd, clientCreateCmd, clientUpdateCmd, clientToggleCmd, clientDeleteCmd, kickCmd)
 	return grp
 }
 
@@ -381,11 +454,14 @@ func ipsecGroup(app *cliapp.Runtime) *cobra.Command {
 	}
 	grp.AddCommand(
 		clientsCmd,
+		getByIDCmd(app, "client-get ID", "Get an IPSec client", "/vpn/ipsec/clients/"),
 		createCmd,
-		writeCmd(app, "client-update ID", "Update an IPSec client", true, ipsecClientFieldMap, nil, nil,
+		updateByIDCmd(app, "client-update ID", "Update an IPSec client", ipsecClientFieldMap, ipsecClientUpdateInputFields, cliapp.APIBase+"/vpn/ipsec/clients/"),
+		writeCmd(app, "client-toggle ID", "Enable/disable an IPSec client", true, map[string]string{"enabled": "enabled"}, nil, nil,
 			func(body interface{}, id string) (json.RawMessage, error) {
-				return app.APIClient.Put(cliapp.APIBase+"/vpn/ipsec/clients/"+id, body)
+				return app.APIClient.Patch(cliapp.APIBase+"/vpn/ipsec/clients/"+id, body)
 			}),
+		deleteByIDCmd(app, "client-delete ID", "Delete an IPSec client", "/vpn/ipsec/clients/"),
 		deleteByIDCmd(app, "kick ID", "Kick an active IPSec client", "/vpn/ipsec/clients/"),
 	)
 	return grp
@@ -457,6 +533,17 @@ func wireguardGroup(app *cliapp.Runtime) *cobra.Command {
 			return origRunE(cmd, args)
 		}
 	}
+	wgUpdateCmd := updateByIDCmd(app, "update ID", "Update a WireGuard tunnel", wireguardFieldMap, wireguardInputFields, cliapp.APIBase+"/vpn/wireguard/")
+	cliapp.MarkFlagsRequired(wgUpdateCmd, "interface")
+	{
+		origRunE := wgUpdateCmd.RunE
+		wgUpdateCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := cliapp.RequireFlags(cmd, "interface"); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
 	peerCreateCmd := writeCmd(app, "peer-create ID", "Create a peer on a WireGuard tunnel", true, wireguardPeerFieldMap, nil, wireguardPeerDefaults,
 		func(body interface{}, id string) (json.RawMessage, error) {
 			return app.APIClient.Post(cliapp.APIBase+"/vpn/wireguard/"+id+"/peers", body)
@@ -475,17 +562,17 @@ func wireguardGroup(app *cliapp.Runtime) *cobra.Command {
 		listCmd,
 		getByIDCmd(app, "get ID", "Get a WireGuard tunnel", "/vpn/wireguard/"),
 		wgCreateCmd,
-		writeCmd(app, "update ID", "Update a WireGuard tunnel", true, wireguardFieldMap, nil, nil,
-			func(body interface{}, id string) (json.RawMessage, error) {
-				return app.APIClient.Put(cliapp.APIBase+"/vpn/wireguard/"+id, body)
-			}),
+		wgUpdateCmd,
 		writeCmd(app, "toggle ID", "Enable/disable a WireGuard tunnel", true, map[string]string{"enabled": "enabled"}, nil, nil,
 			func(body interface{}, id string) (json.RawMessage, error) {
 				return app.APIClient.Patch(cliapp.APIBase+"/vpn/wireguard/"+id, body)
 			}),
 		deleteByIDCmd(app, "delete ID", "Delete a WireGuard tunnel", "/vpn/wireguard/"),
 		peersListCmd,
+		peerGetCmd(app),
 		peerCreateCmd,
+		peerUpdateCmd(app),
+		peerToggleCmd(app),
 		peerDeleteCmd(app),
 	)
 	return grp
@@ -508,6 +595,124 @@ func getByIDCmd(app *cliapp.Runtime, use, short, apiPath string) *cobra.Command 
 			return nil
 		},
 	}
+}
+
+func updateByIDCmd(app *cliapp.Runtime, use, short string, fieldMap map[string]string, inputFields []string, apiPathPrefix string) *cobra.Command {
+	c := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+	}
+	addBodyFlags(c, fieldMap)
+	c.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := app.RequireAuth(); err != nil {
+			return err
+		}
+		data, _ := cmd.Flags().GetString("data")
+		body, err := buildFullBody(app, cmd, data, fieldMap, inputFields, apiPathPrefix+args[0], args[0])
+		if err != nil {
+			return err
+		}
+		raw, err := app.APIClient.Put(apiPathPrefix+args[0], body)
+		if err != nil {
+			return err
+		}
+		app.PrintRaw(raw)
+		return nil
+	}
+	return c
+}
+
+func peerGetCmd(app *cliapp.Runtime) *cobra.Command {
+	return &cobra.Command{
+		Use:   "peer-get TUNNEL_ID PEER_ID",
+		Short: "Get a WireGuard peer",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			raw, err := app.APIClient.Get(cliapp.APIBase+"/vpn/wireguard/"+args[0]+"/peers/"+args[1], nil)
+			if err != nil {
+				return err
+			}
+			app.PrintRaw(raw)
+			return nil
+		},
+	}
+}
+
+func peerUpdateCmd(app *cliapp.Runtime) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "peer-update TUNNEL_ID PEER_ID",
+		Short: "Update a WireGuard peer",
+		Args:  cobra.ExactArgs(2),
+	}
+	addBodyFlags(c, wireguardPeerFieldMap)
+	c.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := app.RequireAuth(); err != nil {
+			return err
+		}
+		path := cliapp.APIBase + "/vpn/wireguard/" + args[0] + "/peers/" + args[1]
+		data, _ := cmd.Flags().GetString("data")
+		body, err := buildFullBody(app, cmd, data, wireguardPeerFieldMap, wireguardPeerInputFields, path, args[1])
+		if err != nil {
+			return err
+		}
+		raw, err := app.APIClient.Put(path, body)
+		if err != nil {
+			return err
+		}
+		app.PrintRaw(raw)
+		return nil
+	}
+	return c
+}
+
+func peerToggleCmd(app *cliapp.Runtime) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "peer-toggle TUNNEL_ID PEER_ID",
+		Short: "Enable/disable a WireGuard peer",
+		Args:  cobra.ExactArgs(2),
+	}
+	c.Flags().String("data", "{}", "JSON body (escape hatch)")
+	cliapp.AddEnabledFlag(c)
+	cliapp.MarkFlagsRequired(c, "enabled")
+	c.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := app.RequireAuth(); err != nil {
+			return err
+		}
+		if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
+			return err
+		}
+		data, _ := cmd.Flags().GetString("data")
+		body, err := cliapp.MergeDataWithFlags(data, cmd, map[string]string{"enabled": "enabled"})
+		if err != nil {
+			return err
+		}
+		raw, err := app.APIClient.Patch(cliapp.APIBase+"/vpn/wireguard/"+args[0]+"/peers/"+args[1], body)
+		if err != nil {
+			return err
+		}
+		app.PrintRaw(raw)
+		return nil
+	}
+	return c
+}
+
+func addBodyFlags(c *cobra.Command, fieldMap map[string]string) {
+	c.Flags().String("data", "{}", "JSON body (escape hatch)")
+	for flagName := range fieldMap {
+		if flagName == "enabled" {
+			continue
+		}
+		desc := flagDescs[flagName]
+		if desc == "" {
+			desc = flagName + " value"
+		}
+		c.Flags().String(flagName, "", desc)
+	}
+	cliapp.AddEnabledFlag(c)
 }
 
 func peerDeleteCmd(app *cliapp.Runtime) *cobra.Command {
@@ -594,7 +799,7 @@ func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[
 		c.Flags().String(flagName, "", desc)
 	}
 	cliapp.AddEnabledFlag(c)
-	if strings.HasPrefix(use, "toggle") {
+	if isToggleUse(use) {
 		cliapp.MarkFlagsRequired(c, "enabled")
 	}
 
@@ -602,7 +807,7 @@ func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[
 		if err := app.RequireAuth(); err != nil {
 			return err
 		}
-		if strings.HasPrefix(use, "toggle") {
+		if isToggleUse(use) {
 			if err := cliapp.RequireFlags(cmd, "enabled"); err != nil {
 				return err
 			}
@@ -649,8 +854,13 @@ func writeCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap map[
 	return c
 }
 
-// configCmdWithFlags builds a --data config command with optional semantic flags.
-func configCmdWithFlags(app *cliapp.Runtime, use, short string, addFlags func(*cobra.Command), fieldMap map[string]string, fn callWithBody) *cobra.Command {
+func isToggleUse(use string) bool {
+	action := strings.Fields(use)
+	return len(action) > 0 && strings.Contains(action[0], "toggle")
+}
+
+// configCmdWithFlags builds a full-body config PUT command with optional semantic flags.
+func configCmdWithFlags(app *cliapp.Runtime, use, short string, addFlags func(*cobra.Command), fieldMap map[string]string, inputFields []string, apiPath string) *cobra.Command {
 	c := &cobra.Command{Use: use, Short: short}
 	c.Flags().String("data", "{}", "JSON body")
 	if addFlags != nil {
@@ -661,17 +871,11 @@ func configCmdWithFlags(app *cliapp.Runtime, use, short string, addFlags func(*c
 			return err
 		}
 		data, _ := cmd.Flags().GetString("data")
-		var body interface{}
-		var err error
-		if fieldMap != nil {
-			body, err = cliapp.MergeDataWithFlags(data, cmd, fieldMap)
-		} else {
-			body, err = cliapp.ParseJSON(data)
-		}
+		body, err := buildFullBody(app, cmd, data, fieldMap, inputFields, apiPath, "")
 		if err != nil {
 			return err
 		}
-		raw, err := fn(body, "")
+		raw, err := app.APIClient.Put(apiPath, body)
 		if err != nil {
 			return err
 		}
@@ -679,4 +883,100 @@ func configCmdWithFlags(app *cliapp.Runtime, use, short string, addFlags func(*c
 		return nil
 	}
 	return c
+}
+
+func buildFullBody(app *cliapp.Runtime, cmd *cobra.Command, data string, fieldMap map[string]string, inputFields []string, getPath string, fallbackID string) (map[string]interface{}, error) {
+	changes, err := cliapp.MergeDataWithFlags(data, cmd, fieldMap)
+	if err != nil {
+		return nil, err
+	}
+	readClient := app.APIClient
+	if app.APIClient.DryRun {
+		readClient = app.NewClient(app.Session.BaseURL, app.Session.Token)
+	}
+	raw, err := readClient.Get(getPath, nil)
+	if err != nil {
+		if hasAllInputFields(changes, inputFields) {
+			return changes, nil
+		}
+		return nil, err
+	}
+	current, err := extractVPNInputObject(raw, inputFields)
+	if err != nil {
+		if hasAllInputFields(changes, inputFields) {
+			return changes, nil
+		}
+		return nil, err
+	}
+	for k, v := range changes {
+		current[k] = v
+	}
+	if fallbackID != "" && hasInputField(inputFields, "id") {
+		if _, exists := current["id"]; !exists {
+			current["id"] = fallbackID
+		}
+	}
+	return current, nil
+}
+
+func extractVPNInputObject(raw json.RawMessage, inputFields []string) (map[string]interface{}, error) {
+	var v interface{}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil, err
+	}
+	obj, err := findFirstVPNObject(v)
+	if err != nil {
+		return nil, err
+	}
+	if len(inputFields) == 0 {
+		return obj, nil
+	}
+	out := map[string]interface{}{}
+	for _, key := range inputFields {
+		if val, ok := obj[key]; ok {
+			out[key] = val
+		}
+	}
+	return out, nil
+}
+
+func findFirstVPNObject(v interface{}) (map[string]interface{}, error) {
+	switch data := v.(type) {
+	case map[string]interface{}:
+		if rows, ok := data["data"].([]interface{}); ok {
+			return findFirstVPNObject(rows)
+		}
+		if rows, ok := data["results"].([]interface{}); ok {
+			return findFirstVPNObject(rows)
+		}
+		if rows, ok := data["iface_data"].([]interface{}); ok {
+			return findFirstVPNObject(rows)
+		}
+		return data, nil
+	case []interface{}:
+		if len(data) == 0 {
+			return nil, &cliapp.ValidationError{Message: "empty VPN response"}
+		}
+		return findFirstVPNObject(data[0])
+	default:
+		return nil, &cliapp.ValidationError{Message: "unexpected VPN response"}
+	}
+}
+
+func hasAllInputFields(body map[string]interface{}, inputFields []string) bool {
+	for _, key := range inputFields {
+		if _, ok := body[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func hasInputField(fields []string, want string) bool {
+	for _, field := range fields {
+		if field == want {
+			return true
+		}
+	}
+	return false
 }

--- a/skills/vpn.md
+++ b/skills/vpn.md
@@ -9,29 +9,33 @@ description: iKuai VPN — PPTP, L2TP, OpenVPN, IKEv2, IPSec, WireGuard server c
 
 ```bash
 # 服务配置
-ikuai-cli vpn pptp get
-ikuai-cli vpn pptp set --enabled yes --server-ip "10.0.0.1" --server-port 1723 --addr-pool "10.0.0.2-10.0.0.254" --dns1 "114.114.114.114" --dns2 "119.29.29.29" --open-mppe 2 --mtu 1400 --mru 1400
-# 全量更新，需传所有字段
+ikuai-cli vpn pptp get --format json
+ikuai-cli vpn pptp set --enabled no --format json
 
 # 客户端 CRUD
-ikuai-cli vpn pptp clients
-ikuai-cli vpn pptp client-create --name pptp_office --server "vpn.example.com" --username user1 --password "123456" --interface auto
-ikuai-cli vpn pptp client-update <ID> --server "vpn2.example.com"
-ikuai-cli vpn pptp kick <ID>
+ikuai-cli vpn pptp clients --format json
+ikuai-cli vpn pptp client-create --name pptpoffice --server "vpn.example.com" --username user1 --password "123456" --interface auto --enabled no --format json
+ikuai-cli vpn pptp client-get <ID> --format json
+ikuai-cli vpn pptp client-update <ID> --server "vpn2.example.com" --format json
+ikuai-cli vpn pptp client-toggle <ID> --enabled no --format json
+ikuai-cli vpn pptp client-delete <ID> --yes --format json
+ikuai-cli vpn pptp kick <ID> --yes --format json
 ```
 
-L2TP server set 同理：`--enabled`, `--server-ip`, `--server-port`, `--addr-pool`, `--dns1`, `--dns2`, `--mtu`, `--mru`, `--ipsec-secret`, `--leftid`, `--rightid`, `--force-ipsec`（全量更新）。
-L2TP 客户端 name 需以 `l2tp` 开头。
-
-OpenVPN/IKEv2 server set 字段多（含证书），建议用 `--data` 全量传 JSON。
+L2TP 命令同理：`vpn l2tp get/set/clients/client-create/client-get/client-update/client-toggle/client-delete/kick`。L2TP 客户端 name 需以 `l2tp` 开头。
 
 ## OpenVPN
 
 ```bash
-ikuai-cli vpn openvpn get
-ikuai-cli vpn openvpn clients
-ikuai-cli vpn openvpn client-create --name ovpn_office --remote-addr "vpn.example.com" --username user1 --password "123456" --ca "<CA证书>" --interface auto
-ikuai-cli vpn openvpn kick <ID>
+ikuai-cli vpn openvpn get --format json
+ikuai-cli vpn openvpn set --enabled no --format json
+ikuai-cli vpn openvpn clients --format json
+ikuai-cli vpn openvpn client-create --name ovpnoffice --remote-addr "vpn.example.com" --username user1 --password "123456" --ca "<CA证书>" --interface auto --enabled no --format json
+ikuai-cli vpn openvpn client-get <ID> --format json
+ikuai-cli vpn openvpn client-update <ID> --comment "updated" --format json
+ikuai-cli vpn openvpn client-toggle <ID> --enabled no --format json
+ikuai-cli vpn openvpn client-delete <ID> --yes --format json
+ikuai-cli vpn openvpn kick <ID> --yes --format json
 ```
 
 `--ca` 必须传真实 CA 证书内容。
@@ -39,10 +43,15 @@ ikuai-cli vpn openvpn kick <ID>
 ## IKEv2
 
 ```bash
-ikuai-cli vpn ikev2 get
-ikuai-cli vpn ikev2 clients
-ikuai-cli vpn ikev2 client-create --name iked_office --remote-addr "vpn.example.com" --interface auto --left-id "localid" --username user1 --password "123456"
-ikuai-cli vpn ikev2 kick <ID>
+ikuai-cli vpn ikev2 get --format json
+ikuai-cli vpn ikev2 set --enabled no --format json
+ikuai-cli vpn ikev2 clients --format json
+ikuai-cli vpn ikev2 client-create --name ikedoffice --remote-addr "vpn.example.com" --interface auto --left-id "localid" --username user1 --password "123456" --enabled no --format json
+ikuai-cli vpn ikev2 client-get <ID> --format json
+ikuai-cli vpn ikev2 client-update <ID> --comment "updated" --format json
+ikuai-cli vpn ikev2 client-toggle <ID> --enabled no --format json
+ikuai-cli vpn ikev2 client-delete <ID> --yes --format json
+ikuai-cli vpn ikev2 kick <ID> --yes --format json
 ```
 
 name 需以 `iked` 开头，authby=mschapv2 时 username 必填。
@@ -50,25 +59,33 @@ name 需以 `iked` 开头，authby=mschapv2 时 username 必填。
 ## IPSec
 
 ```bash
-ikuai-cli vpn ipsec clients
-ikuai-cli vpn ipsec client-create --name ipsec_site --remote-addr "10.0.0.1" --interface wan1 --left-subnet "192.168.1.0/24" --right-subnet "192.168.2.0/24" --secret "psk123"
+ikuai-cli vpn ipsec clients --format json
+ikuai-cli vpn ipsec client-create --name ipsecsite --remote-addr "10.0.0.1" --interface wan1 --left-subnet "192.168.1.0/24" --right-subnet "192.168.2.0/24" --secret "psk123" --enabled no --format json
+ikuai-cli vpn ipsec client-get <ID> --format json
+ikuai-cli vpn ipsec client-update <ID> --comment "updated" --format json
+ikuai-cli vpn ipsec client-toggle <ID> --enabled no --format json
+ikuai-cli vpn ipsec client-delete <ID> --yes --format json
+ikuai-cli vpn ipsec kick <ID> --yes --format json
 # defaults: keyexchange=ikev2, authby=secret, dpdaction=none, ikelifetime=3, lifetime=1
-ikuai-cli vpn ipsec kick <ID>
 ```
 
 ## WireGuard
 
 ```bash
 # 隧道
-ikuai-cli vpn wireguard list
-ikuai-cli vpn wireguard create --name wg_site --address "10.9.0.1/24" --private-key "<base64>" --public-key "<base64>"
+ikuai-cli vpn wireguard list --format json
+ikuai-cli vpn wireguard create --name wgsite --address "10.9.0.1/24" --interface auto --private-key "<base64>" --public-key "<base64>" --enabled no --format json
 # defaults: interface=auto, port=5000, mtu=1420
-ikuai-cli vpn wireguard get <ID>
-ikuai-cli vpn wireguard toggle <ID> --enabled no
-ikuai-cli vpn wireguard delete <ID>
+ikuai-cli vpn wireguard get <ID> --format json
+ikuai-cli vpn wireguard update <ID> --interface auto --port 5001 --format json
+ikuai-cli vpn wireguard toggle <ID> --enabled no --format json
+ikuai-cli vpn wireguard delete <ID> --yes --format json
 
 # 对端
-ikuai-cli vpn wireguard peers <TUNNEL_ID>
-ikuai-cli vpn wireguard peer-create <TUNNEL_ID> --public-key "<base64>" --allow-ips "10.9.0.2/32" --interface wg0
-ikuai-cli vpn wireguard peer-delete <TUNNEL_ID> <PEER_ID>
+ikuai-cli vpn wireguard peers <TUNNEL_ID> --format json
+ikuai-cli vpn wireguard peer-create <TUNNEL_ID> --public-key "<base64>" --allow-ips "10.9.0.2/32" --interface wgsite --enabled no --format json
+ikuai-cli vpn wireguard peer-get <TUNNEL_ID> <PEER_ID> --format json
+ikuai-cli vpn wireguard peer-update <TUNNEL_ID> <PEER_ID> --interface wgsite --comment "updated" --format json
+ikuai-cli vpn wireguard peer-toggle <TUNNEL_ID> <PEER_ID> --enabled no --format json
+ikuai-cli vpn wireguard peer-delete <TUNNEL_ID> <PEER_ID> --yes --format json
 ```


### PR DESCRIPTION
## Summary

- Complete VPN command regression fixes for PPTP, L2TP, OpenVPN, IKEv2, IPSec, and WireGuard.
- Add missing VPN client and WireGuard peer commands, with full-body update handling aligned to API behavior.
- Refresh VPN usage docs and CLI reference examples for the verified command surface.