### PR TITLE
fix(monitor): align protocol query parameters with yaml

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -81,7 +81,7 @@ ikuai-cli monitor protocols
 ikuai-cli monitor protocols-history
 ikuai-cli monitor app-traffic-summary
 ikuai-cli monitor app-protocols-load
-ikuai-cli monitor app-protocols-history --appids 2580003,2580004
+ikuai-cli monitor app-protocols-history --appids 2580003,2580004 --starttime 1773215100 --stoptime 1773218700
 ikuai-cli monitor app-protocols-terminals --appid 2580003
 ikuai-cli monitor wireless-stats
 ikuai-cli monitor wireless-score

--- a/internal/cliapp/helpers.go
+++ b/internal/cliapp/helpers.go
@@ -23,9 +23,16 @@ func ParseJSON(s string) (interface{}, error) {
 }
 
 func ListParams(page, pageSize int, filter, order, orderBy string) map[string]string {
+	return ListParamsWithPageSizeKey(page, pageSize, filter, order, orderBy, "page_size")
+}
+
+func ListParamsWithPageSizeKey(page, pageSize int, filter, order, orderBy, pageSizeKey string) map[string]string {
+	if pageSizeKey == "" {
+		pageSizeKey = "page_size"
+	}
 	p := map[string]string{
 		"page":      fmt.Sprint(page),
-		"page_size": fmt.Sprint(pageSize),
+		pageSizeKey: fmt.Sprint(pageSize),
 	}
 	if filter != "" {
 		p["filter"] = filter

--- a/internal/cliapp/helpers_test.go
+++ b/internal/cliapp/helpers_test.go
@@ -155,6 +155,16 @@ func TestListParams(t *testing.T) {
 	}
 }
 
+func TestListParamsWithPageSizeKey(t *testing.T) {
+	p := ListParamsWithPageSizeKey(2, 50, "", "", "", "limit")
+	if p["page"] != "2" || p["limit"] != "50" {
+		t.Fatalf("page/limit wrong: %v", p)
+	}
+	if _, ok := p["page_size"]; ok {
+		t.Fatalf("page_size should not be present: %v", p)
+	}
+}
+
 func TestListParamsOmitsEmpty(t *testing.T) {
 	p := ListParams(1, 20, "", "", "")
 	if _, ok := p["filter"]; ok {

--- a/internal/cmd/monitor/command.go
+++ b/internal/cmd/monitor/command.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/ikuaidev/ikuai-cli/internal/cliapp"
 	"github.com/spf13/cobra"
@@ -299,7 +300,7 @@ func monitorAppTrafficSummaryCmd(app *cliapp.Runtime) *cobra.Command {
 			page, pageSize, filter, order, orderBy := cliapp.GetListParams(cmd)
 			app.DefaultColumns = []string{"id", "appname", "appname_level1", "appname_level2", "total_up", "total_down", "total", "appid"}
 			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/app-traffic-summary",
-				cliapp.ListParams(page, pageSize, filter, order, orderBy))
+				cliapp.ListParamsWithPageSizeKey(page, pageSize, filter, order, orderBy, "limit"))
 			if err != nil {
 				return err
 			}
@@ -350,9 +351,14 @@ func monitorAppProtocolsHistoryCmd(app *cliapp.Runtime) *cobra.Command {
 			}
 			app.DefaultColumns = []string{"id", "appname", "timestamp", "upload", "download", "total"}
 			appids, _ := cmd.Flags().GetString("appids")
-			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/app-protocols/history-load", map[string]string{
-				"appids": appids,
-			})
+			params := map[string]string{"appids": appids}
+			if starttime, _ := cmd.Flags().GetInt64("starttime"); starttime > 0 {
+				params["starttime"] = strconv.FormatInt(starttime, 10)
+			}
+			if stoptime, _ := cmd.Flags().GetInt64("stoptime"); stoptime > 0 {
+				params["stoptime"] = strconv.FormatInt(stoptime, 10)
+			}
+			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/app-protocols/history-load", params)
 			if err != nil {
 				return err
 			}
@@ -361,6 +367,8 @@ func monitorAppProtocolsHistoryCmd(app *cliapp.Runtime) *cobra.Command {
 		},
 	}
 	c.Flags().String("appids", "", "App protocol IDs, comma-separated (required, e.g. 2580003,2580004)")
+	c.Flags().Int64("starttime", 0, "Start Unix timestamp")
+	c.Flags().Int64("stoptime", 0, "Stop Unix timestamp")
 	_ = c.MarkFlagRequired("appids")
 	return c
 }

--- a/internal/cmd/monitor/command_test.go
+++ b/internal/cmd/monitor/command_test.go
@@ -47,6 +47,78 @@ func TestSystemCommandRequestsMonitoringSystemEndpoint(t *testing.T) {
 	}
 }
 
+func TestAppProtocolsHistoryPassesYamlQueryParameters(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			if req.URL.Path != "/api/v4.0/monitoring/app-protocols/history-load" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/monitoring/app-protocols/history-load")
+			}
+			query := req.URL.Query()
+			for name, want := range map[string]string{
+				"appids":    "2580003,2580004",
+				"starttime": "1773215100",
+				"stoptime":  "1773218700",
+			} {
+				if got := query.Get(name); got != want {
+					t.Fatalf("query %s = %q, want %q", name, got, want)
+				}
+			}
+			return jsonResponse(`{"code":0,"message":"ok","data":[{"appid":2580003}]}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"app-protocols-history", "--appids", "2580003,2580004", "--starttime", "1773215100", "--stoptime", "1773218700"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestAppTrafficSummaryMapsPageSizeToYamlLimit(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			if req.URL.Path != "/api/v4.0/monitoring/app-traffic-summary" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/monitoring/app-traffic-summary")
+			}
+			query := req.URL.Query()
+			if got := query.Get("page"); got != "2" {
+				t.Fatalf("page = %q, want %q", got, "2")
+			}
+			if got := query.Get("limit"); got != "100" {
+				t.Fatalf("limit = %q, want %q", got, "100")
+			}
+			if got := query.Get("page_size"); got != "" {
+				t.Fatalf("page_size = %q, want empty", got)
+			}
+			return jsonResponse(`{"code":0,"message":"ok","results":{"proto3_day":[],"proto3_day_total":0}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"app-traffic-summary", "--page", "2", "--page-size", "100"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
 type roundTripFunc func(req *http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/skills/monitor.md
+++ b/skills/monitor.md
@@ -62,7 +62,7 @@ ikuai-cli monitor protocols --format json            # Protocol distribution
 ikuai-cli monitor protocols-history --format json    # Protocol history
 ikuai-cli monitor app-traffic-summary --format json  # App-layer traffic summary (24h)
 ikuai-cli monitor app-protocols-load --format json   # Current app protocol load
-ikuai-cli monitor app-protocols-history --format json --appids 2580003,2580004  # App protocol rate history
+ikuai-cli monitor app-protocols-history --format json --appids 2580003,2580004 --starttime 1773215100 --stoptime 1773218700  # App protocol rate history
 ikuai-cli monitor app-protocols-terminals --format json --appid 2580003         # Terminals using an app
 ```
 


### PR DESCRIPTION
## Summary

- Keep monitor pagination UX on `--page` / `--page-size` while mapping `app-traffic-summary` page size to the YAML `limit` query.
- Add unit coverage for monitor query parameter mapping.
- Update monitor command docs for `app-protocols-history` time range flags.