### PR TITLE
fix(monitor): align query parameters with yaml

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -54,15 +54,15 @@ ikuai-cli auth clear
 
 ```bash
 ikuai-cli monitor system
-ikuai-cli monitor cpu
-ikuai-cli monitor cpu --time-range day --aggregate max
-ikuai-cli monitor memory
-ikuai-cli monitor disk
-ikuai-cli monitor temp
-ikuai-cli monitor terminals
-ikuai-cli monitor connections
-ikuai-cli monitor network-load
-ikuai-cli monitor downstream
+ikuai-cli monitor cpu --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor cpu --time-range day --start-time 1773215100 --end-time 1773301500 --aggregate max
+ikuai-cli monitor memory --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor disk --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor temp --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor terminals --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor connections --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor network-load --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor downstream --page 1 --page-size 20 --device camera --status 1
 ikuai-cli monitor interfaces
 ikuai-cli monitor interfaces-traffic
 ikuai-cli monitor interfaces-config
@@ -74,23 +74,23 @@ ikuai-cli monitor clients-ip6-online
 ikuai-cli monitor clients-ip6-offline
 ikuai-cli monitor traffic-summary
 ikuai-cli monitor traffic-load --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c
-ikuai-cli monitor client-protocols --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c
-ikuai-cli monitor client-protocols-history --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c
-ikuai-cli monitor client-app-protocols --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c
+ikuai-cli monitor client-protocols --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c --starttime 1773304236 --stoptime 1773304246
+ikuai-cli monitor client-protocols-history --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c --starttime 1773304236 --stoptime 1773304246
+ikuai-cli monitor client-app-protocols --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c --page-size 10
 ikuai-cli monitor protocols
 ikuai-cli monitor protocols-history
 ikuai-cli monitor app-traffic-summary
-ikuai-cli monitor app-protocols-load
+ikuai-cli monitor app-protocols-load --page 1 --page-size 20 --order desc --order-by total_down
 ikuai-cli monitor app-protocols-history --appids 2580003,2580004 --starttime 1773215100 --stoptime 1773218700
 ikuai-cli monitor app-protocols-terminals --appid 2580003
 ikuai-cli monitor wireless-stats
 ikuai-cli monitor wireless-score
-ikuai-cli monitor wireless-traffic
-ikuai-cli monitor ssid-clients
-ikuai-cli monitor channel-clients
-ikuai-cli monitor cameras
-ikuai-cli monitor flow-shunting
-ikuai-cli monitor switch
+ikuai-cli monitor wireless-traffic --apmac 00:00:00:00:00:00
+ikuai-cli monitor ssid-clients --ssid iKuai01_2G
+ikuai-cli monitor channel-clients --channel 6
+ikuai-cli monitor cameras --page 1 --page-size 20 --keyword Hikvision
+ikuai-cli monitor flow-shunting --type data
+ikuai-cli monitor switch --page 1 --page-size 20 --keyword switch
 ```
 
 ## Network

--- a/internal/cliapp/helpers.go
+++ b/internal/cliapp/helpers.go
@@ -47,15 +47,19 @@ func ListParamsWithPageSizeKey(page, pageSize int, filter, order, orderBy, pageS
 }
 
 func AddListFlags(cmd *cobra.Command) {
-	cmd.Flags().IntP("page", "p", 1, "Page number")
-	cmd.Flags().Int("page-size", 20, "Items per page")
-	// --limit is planned but not yet implemented; omitted from registration to avoid misleading users.
+	AddPaginationFlags(cmd)
 	cmd.Flags().String("filter", "", "Filter: field==value, & for AND, comma for OR")
 	cmd.Flags().String("order", "", "Sort direction: asc|desc")
 	cmd.Flags().String("order-by", "", "Sort field")
 	_ = cmd.RegisterFlagCompletionFunc("order", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"asc", "desc"}, cobra.ShellCompDirectiveNoFileComp
 	})
+}
+
+func AddPaginationFlags(cmd *cobra.Command) {
+	cmd.Flags().IntP("page", "p", 1, "Page number")
+	cmd.Flags().Int("page-size", 20, "Items per page")
+	// --limit is planned but not yet implemented; omitted from registration to avoid misleading users.
 }
 
 func GetListParams(cmd *cobra.Command) (page, pageSize int, filter, order, orderBy string) {

--- a/internal/cmd/monitor/command.go
+++ b/internal/cmd/monitor/command.go
@@ -14,8 +14,8 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		Short: "System monitoring",
 		Long:  `Real-time system monitoring: CPU, memory, interfaces, online clients, protocols, and traffic statistics.`,
 		Example: `  ikuai-cli monitor system
-  ikuai-cli monitor cpu
-  ikuai-cli monitor memory
+  ikuai-cli monitor cpu --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+  ikuai-cli monitor memory --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
   ikuai-cli monitor clients-online`,
 	}
 
@@ -27,7 +27,7 @@ func New(app *cliapp.Runtime) *cobra.Command {
 	monitorCmd.AddCommand(loadCmd(app, "terminals", "Terminal count history", "/monitoring/terminals"))
 	monitorCmd.AddCommand(loadCmd(app, "connections", "Connection count history", "/monitoring/connections"))
 	monitorCmd.AddCommand(loadCmd(app, "network-load", "Network load history", "/monitoring/network"))
-	monitorCmd.AddCommand(simpleGetCmd(app, "downstream", "Downstream traffic", "/monitoring/downstream",
+	monitorCmd.AddCommand(legacyMonitorListCmd(app, "downstream", "Downstream traffic", "/monitoring/downstream",
 		[]string{"id", "name", "ip_addr", "device", "method", "status", "port", "protocol", "enabled"}))
 
 	onlineCols := []string{"id", "ip_addr", "mac", "hostname", "interface", "upload", "download", "connect_num", "uptime", "client_type", "comment"}
@@ -38,16 +38,14 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		pagedCmd(app, "clients-offline", "Offline IPv4 clients", "/monitoring/clients-offline", offlineCols),
 		pagedCmd(app, "clients-ip6-online", "Online IPv6 clients", "/monitoring/clients-ip6-online", onlineCols),
 		pagedCmd(app, "clients-ip6-offline", "Offline IPv6 clients", "/monitoring/clients-ip6-offline", offlineCols),
-		pagedCmd(app, "traffic-summary", "Client traffic summary", "/monitoring/clients-traffic-summary",
-			[]string{"id", "ip_addr", "mac", "username", "sum_total_up", "sum_total_down", "sum_total", "comment"}),
+		monitorTrafficSummaryCmd(app),
 		monitorTrafficLoadCmd(app),
 		monitorClientProtocolsCmd(app),
 		monitorClientProtocolsHistoryCmd(app),
 		monitorClientAppProtocolsCmd(app),
 		monitorAppTrafficSummaryCmd(app),
-		simpleGetCmd(app, "protocols", "Protocol distribution", "/monitoring/protocols", nil),
-		simpleGetCmd(app, "protocols-history", "Protocol history", "/monitoring/protocols/history-load",
-			[]string{"proto_name", "timestamp", "upload", "download", "total"}),
+		monitorProtocolsCmd(app),
+		monitorProtocolsHistoryCmd(app),
 		monitorAppProtocolsLoadCmd(app),
 		monitorAppProtocolsHistoryCmd(app),
 		monitorAppProtocolsTerminalsCmd(app),
@@ -58,13 +56,13 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		simpleGetCmd(app, "interfaces-traffic-v6", "IPv6 interface traffic", "/monitoring/interfaces-traffic-v6", nil),
 		simpleGetCmd(app, "wireless-stats", "Wireless statistics", "/monitoring/wireless-statistics", nil),
 		simpleGetCmd(app, "wireless-score", "Wireless quality score", "/monitoring/wireless-score", nil),
-		simpleGetCmd(app, "wireless-traffic", "Per-AP traffic", "/monitoring/wireless-traffic", nil),
-		simpleGetCmd(app, "ssid-clients", "SSID client distribution", "/monitoring/ssid-clients", nil),
-		simpleGetCmd(app, "channel-clients", "Channel client distribution", "/monitoring/channel-clients", nil),
-		simpleGetCmd(app, "cameras", "IP camera list", "/monitoring/cameras",
+		monitorWirelessTrafficCmd(app),
+		monitorSSIDClientsCmd(app),
+		monitorChannelClientsCmd(app),
+		legacyMonitorListCmd(app, "cameras", "IP camera list", "/monitoring/cameras",
 			[]string{"id", "tagname", "name", "vendor", "ip_addr", "mac", "flag", "status", "enabled"}),
-		simpleGetCmd(app, "flow-shunting", "Traffic shunting", "/monitoring/flow-shunting", nil),
-		simpleGetCmd(app, "switch", "Switch port monitoring", "/monitoring/switch",
+		monitorFlowShuntingCmd(app),
+		legacyMonitorListCmd(app, "switch", "Switch port monitoring", "/monitoring/switch",
 			[]string{"id", "name", "ip_addr", "mac", "device", "version", "type", "status"}),
 	} {
 		monitorCmd.AddCommand(c)
@@ -73,9 +71,7 @@ func New(app *cliapp.Runtime) *cobra.Command {
 	return monitorCmd
 }
 
-// loadCmd creates a monitor command for load-type endpoints that support
-// --time-range and --aggregate query parameters.
-// All flags are optional; the router uses server-side defaults when omitted.
+// loadCmd creates a monitor command for load-type endpoints.
 func loadCmd(app *cliapp.Runtime, use, short, apiPath string) *cobra.Command {
 	c := &cobra.Command{
 		Use:   use,
@@ -84,23 +80,29 @@ func loadCmd(app *cliapp.Runtime, use, short, apiPath string) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
-			p := map[string]string{}
-			if timeRange, _ := cmd.Flags().GetString("time-range"); timeRange != "" {
-				switch timeRange {
-				case "hour", "day", "week", "month":
-					p["datetype"] = timeRange // API param name unchanged
-				default:
-					return fmt.Errorf("--time-range must be one of: hour, day, week, month")
-				}
+			if err := cliapp.RequireFlags(cmd, "time-range", "start-time", "end-time", "aggregate"); err != nil {
+				return err
 			}
-			if agg, _ := cmd.Flags().GetString("aggregate"); agg != "" {
-				if agg != "avg" && agg != "max" {
-					return fmt.Errorf("--aggregate must be one of: avg, max")
-				}
-				p["math"] = agg // API param name unchanged
+			timeRange, _ := cmd.Flags().GetString("time-range")
+			switch timeRange {
+			case "hour", "day", "week", "month":
+			default:
+				return fmt.Errorf("--time-range must be one of: hour, day, week, month")
 			}
-			if len(p) == 0 {
-				p = nil
+			agg, _ := cmd.Flags().GetString("aggregate")
+			if agg != "avg" && agg != "max" {
+				return fmt.Errorf("--aggregate must be one of: avg, max")
+			}
+			end, _ := cmd.Flags().GetInt64("end-time")
+			start, _ := cmd.Flags().GetInt64("start-time")
+			if start >= end {
+				return fmt.Errorf("--start-time must be less than --end-time")
+			}
+			p := map[string]string{
+				"datetype":   timeRange,
+				"start_time": strconv.FormatInt(start, 10),
+				"end_time":   strconv.FormatInt(end, 10),
+				"math":       agg,
 			}
 			raw, err := app.APIClient.Get(cliapp.APIBase+apiPath, p)
 			if err != nil {
@@ -110,8 +112,11 @@ func loadCmd(app *cliapp.Runtime, use, short, apiPath string) *cobra.Command {
 			return nil
 		},
 	}
-	c.Flags().String("time-range", "", "Time range: hour, day, week, month")
-	c.Flags().String("aggregate", "", "Aggregation: avg, max")
+	c.Flags().String("time-range", "", "Time range: hour, day, week, month (required)")
+	c.Flags().Int64("start-time", 0, "Start Unix timestamp (required)")
+	c.Flags().Int64("end-time", 0, "End Unix timestamp (required)")
+	c.Flags().String("aggregate", "", "Aggregation: avg, max (required)")
+	cliapp.MarkFlagsRequired(c, "time-range", "start-time", "end-time", "aggregate")
 	return c
 }
 
@@ -151,9 +156,15 @@ func pagedCmd(app *cliapp.Runtime, use, short, apiPath string, defaultCols []str
 			if len(defaultCols) > 0 {
 				app.DefaultColumns = defaultCols
 			}
-			page, pageSize, filter, order, orderBy := cliapp.GetListParams(cmd)
-			raw, err := app.APIClient.Get(cliapp.APIBase+apiPath,
-				cliapp.ListParams(page, pageSize, filter, order, orderBy))
+			page, pageSize, filter, _, _ := cliapp.GetListParams(cmd)
+			p := cliapp.ListParamsWithPageSizeKey(page, pageSize, filter, "", "", "limit")
+			if key, _ := cmd.Flags().GetString("key"); key != "" {
+				p["key"] = key
+			}
+			if pattern, _ := cmd.Flags().GetString("pattern"); pattern != "" {
+				p["pattern"] = pattern
+			}
+			raw, err := app.APIClient.Get(cliapp.APIBase+apiPath, p)
 			if err != nil {
 				return err
 			}
@@ -161,7 +172,76 @@ func pagedCmd(app *cliapp.Runtime, use, short, apiPath string, defaultCols []str
 			return nil
 		},
 	}
-	cliapp.AddListFlags(c)
+	cliapp.AddPaginationFlags(c)
+	c.Flags().String("filter", "", "Filter: field==value, & for AND, comma for OR")
+	c.Flags().String("key", "", "Fuzzy match fields, comma-separated")
+	c.Flags().String("pattern", "", "Fuzzy match pattern")
+	return c
+}
+
+func legacyMonitorListCmd(app *cliapp.Runtime, use, short, apiPath string, defaultCols []string) *cobra.Command {
+	c := &cobra.Command{
+		Use:   use,
+		Short: short,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			if len(defaultCols) > 0 {
+				app.DefaultColumns = defaultCols
+			}
+			page, pageSize, _, order, orderBy := cliapp.GetListParams(cmd)
+			if page < 1 {
+				return fmt.Errorf("--page must be greater than 0")
+			}
+			if pageSize < 1 {
+				return fmt.Errorf("--page-size must be greater than 0")
+			}
+			offset := (page - 1) * pageSize
+			p := map[string]string{
+				"TYPE":   "data",
+				"LIMIT":  fmt.Sprintf("%d,%d", offset, pageSize),
+				"OFFSET": intStr(offset),
+			}
+			if order != "" {
+				p["ORDER"] = order
+			}
+			if orderBy != "" {
+				p["ORDER_BY"] = orderBy
+			}
+			if status, _ := cmd.Flags().GetString("status"); status != "" {
+				if status != "0" && status != "1" {
+					return fmt.Errorf("--status must be 0 or 1")
+				}
+				p["status"] = status
+			}
+			if deviceFlag := cmd.Flags().Lookup("device"); deviceFlag != nil {
+				if device, _ := cmd.Flags().GetString("device"); device != "" {
+					p["device"] = device
+				}
+			}
+			if keywordFlag := cmd.Flags().Lookup("keyword"); keywordFlag != nil {
+				if keyword, _ := cmd.Flags().GetString("keyword"); keyword != "" {
+					p["KEYWORDS"] = keyword
+				}
+			}
+			raw, err := app.APIClient.Get(cliapp.APIBase+apiPath, p)
+			if err != nil {
+				return err
+			}
+			app.PrintRaw(raw)
+			return nil
+		},
+	}
+	cliapp.AddPaginationFlags(c)
+	c.Flags().String("order", "", "Sort direction: asc|desc")
+	c.Flags().String("order-by", "", "Sort field")
+	c.Flags().String("status", "", "Status filter: 0|1")
+	if use == "downstream" {
+		c.Flags().String("device", "", "Device type: router|switches|firewall|server|camera|printer|SmartDevices|ap|other")
+	} else {
+		c.Flags().String("keyword", "", "Keyword search")
+	}
 	return c
 }
 
@@ -173,11 +253,11 @@ func monitorTrafficLoadCmd(app *cliapp.Runtime) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			if err := cliapp.RequireFlags(cmd, "ip", "mac"); err != nil {
+				return err
+			}
 			ip, _ := cmd.Flags().GetString("ip")
 			mac, _ := cmd.Flags().GetString("mac")
-			if ip == "" || mac == "" {
-				return fmt.Errorf("both --ip and --mac are required")
-			}
 			app.DefaultColumns = []string{"timestamp", "upload", "download", "conn_num"}
 			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/clients-traffic-load", map[string]string{
 				"ip": ip, "mac": mac,
@@ -191,8 +271,32 @@ func monitorTrafficLoadCmd(app *cliapp.Runtime) *cobra.Command {
 	}
 	c.Flags().String("ip", "", "Client IP address (required)")
 	c.Flags().String("mac", "", "Client MAC address (required)")
-	_ = c.MarkFlagRequired("ip")
-	_ = c.MarkFlagRequired("mac")
+	cliapp.MarkFlagsRequired(c, "ip", "mac")
+	return c
+}
+
+func monitorTrafficSummaryCmd(app *cliapp.Runtime) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "traffic-summary",
+		Short: "Client traffic summary",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			page, pageSize, _, _, _ := cliapp.GetListParams(cmd)
+			app.DefaultColumns = []string{"id", "ip_addr", "mac", "username", "sum_total_up", "sum_total_down", "sum_total", "comment"}
+			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/clients-traffic-summary", map[string]string{
+				"page":  intStr(page),
+				"limit": intStr(pageSize),
+			})
+			if err != nil {
+				return err
+			}
+			app.PrintRaw(raw)
+			return nil
+		},
+	}
+	cliapp.AddPaginationFlags(c)
 	return c
 }
 
@@ -204,15 +308,20 @@ func monitorClientProtocolsCmd(app *cliapp.Runtime) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			if err := cliapp.RequireFlags(cmd, "ip", "mac"); err != nil {
+				return err
+			}
 			ip, _ := cmd.Flags().GetString("ip")
 			mac, _ := cmd.Flags().GetString("mac")
-			if ip == "" || mac == "" {
-				return fmt.Errorf("both --ip and --mac are required")
-			}
 			app.DefaultColumns = []string{"id", "proto", "proto_name", "total"}
-			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/clients/protocols", map[string]string{
-				"ip": ip, "mac": mac,
-			})
+			params := map[string]string{"ip": ip, "mac": mac}
+			if starttime, _ := cmd.Flags().GetInt64("starttime"); starttime > 0 {
+				params["starttime"] = strconv.FormatInt(starttime, 10)
+			}
+			if stoptime, _ := cmd.Flags().GetInt64("stoptime"); stoptime > 0 {
+				params["stoptime"] = strconv.FormatInt(stoptime, 10)
+			}
+			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/clients/protocols", params)
 			if err != nil {
 				return err
 			}
@@ -222,8 +331,9 @@ func monitorClientProtocolsCmd(app *cliapp.Runtime) *cobra.Command {
 	}
 	c.Flags().String("ip", "", "Client IP address (required)")
 	c.Flags().String("mac", "", "Client MAC address (required)")
-	_ = c.MarkFlagRequired("ip")
-	_ = c.MarkFlagRequired("mac")
+	c.Flags().Int64("starttime", 0, "Start Unix timestamp")
+	c.Flags().Int64("stoptime", 0, "Stop Unix timestamp")
+	cliapp.MarkFlagsRequired(c, "ip", "mac")
 	return c
 }
 
@@ -235,15 +345,20 @@ func monitorClientProtocolsHistoryCmd(app *cliapp.Runtime) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			if err := cliapp.RequireFlags(cmd, "ip", "mac"); err != nil {
+				return err
+			}
 			ip, _ := cmd.Flags().GetString("ip")
 			mac, _ := cmd.Flags().GetString("mac")
-			if ip == "" || mac == "" {
-				return fmt.Errorf("both --ip and --mac are required")
-			}
 			app.DefaultColumns = []string{"id", "proto_name", "timestamp", "upload", "download", "total"}
-			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/clients/protocols/history-load", map[string]string{
-				"ip": ip, "mac": mac,
-			})
+			params := map[string]string{"ip": ip, "mac": mac}
+			if starttime, _ := cmd.Flags().GetInt64("starttime"); starttime > 0 {
+				params["starttime"] = strconv.FormatInt(starttime, 10)
+			}
+			if stoptime, _ := cmd.Flags().GetInt64("stoptime"); stoptime > 0 {
+				params["stoptime"] = strconv.FormatInt(stoptime, 10)
+			}
+			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/clients/protocols/history-load", params)
 			if err != nil {
 				return err
 			}
@@ -253,8 +368,9 @@ func monitorClientProtocolsHistoryCmd(app *cliapp.Runtime) *cobra.Command {
 	}
 	c.Flags().String("ip", "", "Client IP address (required)")
 	c.Flags().String("mac", "", "Client MAC address (required)")
-	_ = c.MarkFlagRequired("ip")
-	_ = c.MarkFlagRequired("mac")
+	c.Flags().Int64("starttime", 0, "Start Unix timestamp")
+	c.Flags().Int64("stoptime", 0, "Stop Unix timestamp")
+	cliapp.MarkFlagsRequired(c, "ip", "mac")
 	return c
 }
 
@@ -266,15 +382,17 @@ func monitorClientAppProtocolsCmd(app *cliapp.Runtime) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			if err := cliapp.RequireFlags(cmd, "ip", "mac"); err != nil {
+				return err
+			}
 			ip, _ := cmd.Flags().GetString("ip")
 			mac, _ := cmd.Flags().GetString("mac")
-			if ip == "" || mac == "" {
-				return fmt.Errorf("both --ip and --mac are required")
-			}
 			app.DefaultColumns = []string{"id", "app_name", "conn_cnt", "upload", "download", "total"}
-			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/clients/app-protocols/load", map[string]string{
-				"ip": ip, "mac": mac,
-			})
+			params := map[string]string{"ip": ip, "mac": mac}
+			if limit, _ := cmd.Flags().GetInt("page-size"); limit > 0 {
+				params["limit"] = intStr(limit)
+			}
+			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/clients/app-protocols/load", params)
 			if err != nil {
 				return err
 			}
@@ -284,8 +402,8 @@ func monitorClientAppProtocolsCmd(app *cliapp.Runtime) *cobra.Command {
 	}
 	c.Flags().String("ip", "", "Client IP address (required)")
 	c.Flags().String("mac", "", "Client MAC address (required)")
-	_ = c.MarkFlagRequired("ip")
-	_ = c.MarkFlagRequired("mac")
+	c.Flags().Int("page-size", 20, "Items per page")
+	cliapp.MarkFlagsRequired(c, "ip", "mac")
 	return c
 }
 
@@ -297,10 +415,10 @@ func monitorAppTrafficSummaryCmd(app *cliapp.Runtime) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
-			page, pageSize, filter, order, orderBy := cliapp.GetListParams(cmd)
+			page, pageSize, _, _, _ := cliapp.GetListParams(cmd)
 			app.DefaultColumns = []string{"id", "appname", "appname_level1", "appname_level2", "total_up", "total_down", "total", "appid"}
 			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/app-traffic-summary",
-				cliapp.ListParamsWithPageSizeKey(page, pageSize, filter, order, orderBy, "limit"))
+				map[string]string{"page": intStr(page), "limit": intStr(pageSize)})
 			if err != nil {
 				return err
 			}
@@ -308,7 +426,50 @@ func monitorAppTrafficSummaryCmd(app *cliapp.Runtime) *cobra.Command {
 			return nil
 		},
 	}
-	cliapp.AddListFlags(c)
+	cliapp.AddPaginationFlags(c)
+	return c
+}
+
+func monitorProtocolsCmd(app *cliapp.Runtime) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "protocols",
+		Short: "Protocol distribution",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			params := timeRangeParams(cmd, "starttime", "stoptime")
+			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/protocols", params)
+			if err != nil {
+				return err
+			}
+			app.PrintRaw(raw)
+			return nil
+		},
+	}
+	addStartStopFlags(c)
+	return c
+}
+
+func monitorProtocolsHistoryCmd(app *cliapp.Runtime) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "protocols-history",
+		Short: "Protocol history",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			app.DefaultColumns = []string{"proto_name", "timestamp", "upload", "download", "total"}
+			params := timeRangeParams(cmd, "starttime", "stoptime")
+			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/protocols/history-load", params)
+			if err != nil {
+				return err
+			}
+			app.PrintRaw(raw)
+			return nil
+		},
+	}
+	addStartStopFlags(c)
 	return c
 }
 
@@ -322,7 +483,7 @@ func monitorAppProtocolsLoadCmd(app *cliapp.Runtime) *cobra.Command {
 			}
 			page, pageSize, _, order, orderBy := cliapp.GetListParams(cmd)
 			app.DefaultColumns = []string{"id", "appname", "conn_cnt", "upload", "download", "total_up", "total_down", "total"}
-			p := map[string]string{"page": intStr(page), "page_size": intStr(pageSize)}
+			p := map[string]string{"page": intStr(page), "limit": intStr(pageSize)}
 			if order != "" {
 				p["order"] = order
 			}
@@ -337,7 +498,9 @@ func monitorAppProtocolsLoadCmd(app *cliapp.Runtime) *cobra.Command {
 			return nil
 		},
 	}
-	cliapp.AddListFlags(c)
+	cliapp.AddPaginationFlags(c)
+	c.Flags().String("order", "", "Sort direction: asc|desc")
+	c.Flags().String("order-by", "", "Sort field")
 	return c
 }
 
@@ -347,6 +510,9 @@ func monitorAppProtocolsHistoryCmd(app *cliapp.Runtime) *cobra.Command {
 		Short: "App-protocol rate history (requires appids)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			if err := cliapp.RequireFlags(cmd, "appids"); err != nil {
 				return err
 			}
 			app.DefaultColumns = []string{"id", "appname", "timestamp", "upload", "download", "total"}
@@ -366,10 +532,10 @@ func monitorAppProtocolsHistoryCmd(app *cliapp.Runtime) *cobra.Command {
 			return nil
 		},
 	}
-	c.Flags().String("appids", "", "App protocol IDs, comma-separated (required, e.g. 2580003,2580004)")
+	c.Flags().String("appids", "", "App protocol IDs, comma-separated, e.g. 2580003,2580004")
 	c.Flags().Int64("starttime", 0, "Start Unix timestamp")
 	c.Flags().Int64("stoptime", 0, "Stop Unix timestamp")
-	_ = c.MarkFlagRequired("appids")
+	cliapp.MarkFlagsRequired(c, "appids")
 	return c
 }
 
@@ -381,10 +547,13 @@ func monitorAppProtocolsTerminalsCmd(app *cliapp.Runtime) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			if err := cliapp.RequireFlags(cmd, "appid"); err != nil {
+				return err
+			}
 			app.DefaultColumns = []string{"id", "ipaddr", "mac", "hostname", "client_type", "conn_cnt", "upload", "download", "total_up"}
-			appid, _ := cmd.Flags().GetString("appid")
+			appid, _ := cmd.Flags().GetInt("appid")
 			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/app-protocols/terminal-load", map[string]string{
-				"appid": appid,
+				"appid": intStr(appid),
 			})
 			if err != nil {
 				return err
@@ -393,9 +562,111 @@ func monitorAppProtocolsTerminalsCmd(app *cliapp.Runtime) *cobra.Command {
 			return nil
 		},
 	}
-	c.Flags().String("appid", "", "App protocol ID (required, e.g. 2580003)")
-	_ = c.MarkFlagRequired("appid")
+	c.Flags().Int("appid", 0, "App protocol ID, e.g. 2580003")
+	cliapp.MarkFlagsRequired(c, "appid")
 	return c
+}
+
+func monitorFlowShuntingCmd(app *cliapp.Runtime) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "flow-shunting",
+		Short: "Traffic shunting",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			value, _ := cmd.Flags().GetString("type")
+			if value != "data" {
+				return fmt.Errorf("--type must be data")
+			}
+			raw, err := app.APIClient.Get(cliapp.APIBase+"/monitoring/flow-shunting", map[string]string{
+				"TYPE": value,
+			})
+			if err != nil {
+				return err
+			}
+			app.PrintRaw(raw)
+			return nil
+		},
+	}
+	c.Flags().String("type", "data", "Response type: data")
+	return c
+}
+
+func monitorWirelessTrafficCmd(app *cliapp.Runtime) *cobra.Command {
+	return simpleGetWithOptionalParamsCmd(app, "wireless-traffic", "Per-AP traffic", "/monitoring/wireless-traffic", nil, func(c *cobra.Command) {
+		c.Flags().String("apmac", "", "AP MAC address")
+	})
+}
+
+func monitorSSIDClientsCmd(app *cliapp.Runtime) *cobra.Command {
+	return simpleGetWithOptionalParamsCmd(app, "ssid-clients", "SSID client distribution", "/monitoring/ssid-clients", nil, func(c *cobra.Command) {
+		c.Flags().String("ssid", "", "SSID name")
+	})
+}
+
+func monitorChannelClientsCmd(app *cliapp.Runtime) *cobra.Command {
+	return simpleGetWithOptionalParamsCmd(app, "channel-clients", "Channel client distribution", "/monitoring/channel-clients", nil, func(c *cobra.Command) {
+		c.Flags().Int("channel", 0, "Wireless channel")
+	})
+}
+
+func simpleGetWithOptionalParamsCmd(app *cliapp.Runtime, use, short, apiPath string, defaultCols []string, addFlags func(*cobra.Command)) *cobra.Command {
+	c := &cobra.Command{
+		Use:   use,
+		Short: short,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := app.RequireAuth(); err != nil {
+				return err
+			}
+			if len(defaultCols) > 0 {
+				app.DefaultColumns = defaultCols
+			}
+			params := map[string]string{}
+			for _, name := range []string{"apmac", "ssid"} {
+				if flag := cmd.Flags().Lookup(name); flag != nil {
+					if val, _ := cmd.Flags().GetString(name); val != "" {
+						params[name] = val
+					}
+				}
+			}
+			if flag := cmd.Flags().Lookup("channel"); flag != nil {
+				if val, _ := cmd.Flags().GetInt("channel"); val > 0 {
+					params["channel"] = intStr(val)
+				}
+			}
+			if len(params) == 0 {
+				params = nil
+			}
+			raw, err := app.APIClient.Get(cliapp.APIBase+apiPath, params)
+			if err != nil {
+				return err
+			}
+			app.PrintRaw(raw)
+			return nil
+		},
+	}
+	addFlags(c)
+	return c
+}
+
+func addStartStopFlags(c *cobra.Command) {
+	c.Flags().Int64("starttime", 0, "Start Unix timestamp")
+	c.Flags().Int64("stoptime", 0, "Stop Unix timestamp")
+}
+
+func timeRangeParams(cmd *cobra.Command, startName, stopName string) map[string]string {
+	params := map[string]string{}
+	if start, _ := cmd.Flags().GetInt64(startName); start > 0 {
+		params[startName] = strconv.FormatInt(start, 10)
+	}
+	if stop, _ := cmd.Flags().GetInt64(stopName); stop > 0 {
+		params[stopName] = strconv.FormatInt(stop, 10)
+	}
+	if len(params) == 0 {
+		return nil
+	}
+	return params
 }
 
 func intStr(n int) string {

--- a/internal/cmd/monitor/command_test.go
+++ b/internal/cmd/monitor/command_test.go
@@ -83,6 +83,133 @@ func TestAppProtocolsHistoryPassesYamlQueryParameters(t *testing.T) {
 	}
 }
 
+func TestLoadCommandPassesYamlTimeParameters(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/api/v4.0/monitoring/cpu" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/monitoring/cpu")
+			}
+			query := req.URL.Query()
+			for name, want := range map[string]string{
+				"datetype":   "day",
+				"start_time": "1773300000",
+				"end_time":   "1773303600",
+				"math":       "max",
+			} {
+				if got := query.Get(name); got != want {
+					t.Fatalf("query %s = %q, want %q", name, got, want)
+				}
+			}
+			return jsonResponse(`{"code":0,"message":"ok","results":{"cpu":[]}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"cpu", "--time-range", "day", "--start-time", "1773300000", "--end-time", "1773303600", "--aggregate", "max"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestLoadCommandRequiresYamlRequiredTimeParameters(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected HTTP request: %s", req.URL.String())
+			return nil, nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"cpu"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want missing required flags")
+	}
+	want := "missing required flags: --time-range, --start-time, --end-time, --aggregate"
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestProtocolsPassesYamlTimeParameters(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/api/v4.0/monitoring/protocols" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/monitoring/protocols")
+			}
+			query := req.URL.Query()
+			if got := query.Get("starttime"); got != "1773215100" {
+				t.Fatalf("starttime = %q, want %q", got, "1773215100")
+			}
+			if got := query.Get("stoptime"); got != "1773218700" {
+				t.Fatalf("stoptime = %q, want %q", got, "1773218700")
+			}
+			return jsonResponse(`{"code":0,"message":"ok","results":{"data":[]}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"protocols", "--starttime", "1773215100", "--stoptime", "1773218700"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestClientProtocolsHistoryPassesYamlTimeQueryParameters(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			if req.URL.Path != "/api/v4.0/monitoring/clients/protocols/history-load" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/monitoring/clients/protocols/history-load")
+			}
+			query := req.URL.Query()
+			for name, want := range map[string]string{
+				"ip":        "192.168.9.199",
+				"mac":       "08:9b:4b:01:7e:7c",
+				"starttime": "1773304236",
+				"stoptime":  "1773304246",
+			} {
+				if got := query.Get(name); got != want {
+					t.Fatalf("query %s = %q, want %q", name, got, want)
+				}
+			}
+			return jsonResponse(`{"code":0,"message":"ok","results":{"data":[]}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"client-protocols-history", "--ip", "192.168.9.199", "--mac", "08:9b:4b:01:7e:7c", "--starttime", "1773304236", "--stoptime", "1773304246"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
 func TestAppTrafficSummaryMapsPageSizeToYamlLimit(t *testing.T) {
 	t.Parallel()
 
@@ -116,6 +243,332 @@ func TestAppTrafficSummaryMapsPageSizeToYamlLimit(t *testing.T) {
 	cmd.SetArgs([]string{"app-traffic-summary", "--page", "2", "--page-size", "100"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestAppTrafficSummaryOnlyExposesYamlFlags(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	cmd := New(app)
+	appTrafficCmd, _, err := cmd.Find([]string{"app-traffic-summary"})
+	if err != nil {
+		t.Fatalf("Find() error = %v", err)
+	}
+	for _, name := range []string{"page", "page-size"} {
+		if appTrafficCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("expected flag %q to exist", name)
+		}
+	}
+	for _, name := range []string{"filter", "order", "order-by"} {
+		if appTrafficCmd.Flags().Lookup(name) != nil {
+			t.Fatalf("flag %q should not be exposed by app-traffic-summary", name)
+		}
+	}
+}
+
+func TestClientListPassesYamlSearchParameters(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/api/v4.0/monitoring/clients-online" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/monitoring/clients-online")
+			}
+			query := req.URL.Query()
+			for name, want := range map[string]string{
+				"key":     "mac,ip_addr",
+				"pattern": "08:9b",
+				"filter":  "interface==lan1",
+			} {
+				if got := query.Get(name); got != want {
+					t.Fatalf("query %s = %q, want %q", name, got, want)
+				}
+			}
+			return jsonResponse(`{"code":0,"message":"ok","results":{"data":[],"total":0}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"clients-online", "--key", "mac,ip_addr", "--pattern", "08:9b", "--filter", "interface==lan1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestClientListOnlyExposesTrimmedYamlFlags(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	cmd := New(app)
+	clientsCmd, _, err := cmd.Find([]string{"clients-online"})
+	if err != nil {
+		t.Fatalf("Find() error = %v", err)
+	}
+	for _, name := range []string{"page", "page-size", "filter", "key", "pattern"} {
+		if clientsCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("expected flag %q to exist", name)
+		}
+	}
+	for _, name := range []string{"order", "order-by"} {
+		if clientsCmd.Flags().Lookup(name) != nil {
+			t.Fatalf("flag %q should not be exposed by clients-online", name)
+		}
+	}
+}
+
+func TestTrafficSummaryMapsPageSizeToYamlLimit(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			if req.URL.Path != "/api/v4.0/monitoring/clients-traffic-summary" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/monitoring/clients-traffic-summary")
+			}
+			query := req.URL.Query()
+			if got := query.Get("page"); got != "2" {
+				t.Fatalf("page = %q, want %q", got, "2")
+			}
+			if got := query.Get("limit"); got != "50" {
+				t.Fatalf("limit = %q, want %q", got, "50")
+			}
+			for _, name := range []string{"page_size", "filter", "order", "order_by"} {
+				if got := query.Get(name); got != "" {
+					t.Fatalf("%s = %q, want empty", name, got)
+				}
+			}
+			return jsonResponse(`{"code":0,"message":"ok","results":{"terminal":[],"terminal_total":0}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"traffic-summary", "--page", "2", "--page-size", "50"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestWirelessCommandsPassYamlFilterParameters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		args      []string
+		path      string
+		queryName string
+		want      string
+		body      string
+	}{
+		{
+			name:      "wireless-traffic apmac",
+			args:      []string{"wireless-traffic", "--apmac", "00:00:00:00:00:00"},
+			path:      "/api/v4.0/monitoring/wireless-traffic",
+			queryName: "apmac",
+			want:      "00:00:00:00:00:00",
+			body:      `{"code":0,"message":"ok","results":{"total_count_flow":[]}}`,
+		},
+		{
+			name:      "ssid-clients ssid",
+			args:      []string{"ssid-clients", "--ssid", "AP_test001"},
+			path:      "/api/v4.0/monitoring/ssid-clients",
+			queryName: "ssid",
+			want:      "AP_test001",
+			body:      `{"code":0,"message":"ok","results":{"ssid_sta_history":[]}}`,
+		},
+		{
+			name:      "channel-clients channel",
+			args:      []string{"channel-clients", "--channel", "3"},
+			path:      "/api/v4.0/monitoring/channel-clients",
+			queryName: "channel",
+			want:      "3",
+			body:      `{"code":0,"message":"ok","results":{"channel_sta_history":[]}}`,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var out bytes.Buffer
+			app := cliapp.New(&out, &out)
+			app.Format = output.JSON
+			app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+			app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if req.URL.Path != tt.path {
+						t.Fatalf("path = %q, want %q", req.URL.Path, tt.path)
+					}
+					if got := req.URL.Query().Get(tt.queryName); got != tt.want {
+						t.Fatalf("query %s = %q, want %q", tt.queryName, got, tt.want)
+					}
+					return jsonResponse(tt.body), nil
+				}),
+			})
+			cmd := New(app)
+			cmd.SetArgs(tt.args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestAppProtocolsLoadMapsPageSizeToYamlLimit(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			if req.URL.Path != "/api/v4.0/monitoring/app-protocols/load" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/monitoring/app-protocols/load")
+			}
+			query := req.URL.Query()
+			for name, want := range map[string]string{
+				"page":     "3",
+				"limit":    "25",
+				"order":    "desc",
+				"order_by": "total_down",
+			} {
+				if got := query.Get(name); got != want {
+					t.Fatalf("query %s = %q, want %q", name, got, want)
+				}
+			}
+			if got := query.Get("page_size"); got != "" {
+				t.Fatalf("page_size = %q, want empty", got)
+			}
+			return jsonResponse(`{"code":0,"message":"ok","results":{"data":[]}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"app-protocols-load", "--page", "3", "--page-size", "25", "--order", "desc", "--order-by", "total_down"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestClientAppProtocolsPassesYamlLimit(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			if req.URL.Path != "/api/v4.0/monitoring/clients/app-protocols/load" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/monitoring/clients/app-protocols/load")
+			}
+			query := req.URL.Query()
+			for name, want := range map[string]string{
+				"ip":    "192.168.9.199",
+				"mac":   "08:9b:4b:01:7e:7c",
+				"limit": "10",
+			} {
+				if got := query.Get(name); got != want {
+					t.Fatalf("query %s = %q, want %q", name, got, want)
+				}
+			}
+			return jsonResponse(`{"code":0,"message":"ok","results":{"data":[]}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"client-app-protocols", "--ip", "192.168.9.199", "--mac", "08:9b:4b:01:7e:7c", "--page-size", "10"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestClientProtocolsPassesYamlTimeQueryParameters(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			if req.URL.Path != "/api/v4.0/monitoring/clients/protocols" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/monitoring/clients/protocols")
+			}
+			query := req.URL.Query()
+			for name, want := range map[string]string{
+				"ip":        "192.168.9.199",
+				"mac":       "08:9b:4b:01:7e:7c",
+				"starttime": "1773304236",
+				"stoptime":  "1773304246",
+			} {
+				if got := query.Get(name); got != want {
+					t.Fatalf("query %s = %q, want %q", name, got, want)
+				}
+			}
+			return jsonResponse(`{"code":0,"message":"ok","results":{"data":[]}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"client-protocols", "--ip", "192.168.9.199", "--mac", "08:9b:4b:01:7e:7c", "--starttime", "1773304236", "--stoptime", "1773304246"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestAppProtocolsTerminalsUsesIntegerAppIDAndCleanRequiredHelp(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/api/v4.0/monitoring/app-protocols/terminal-load" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/monitoring/app-protocols/terminal-load")
+			}
+			if got := req.URL.Query().Get("appid"); got != "2580003" {
+				t.Fatalf("appid = %q, want %q", got, "2580003")
+			}
+			return jsonResponse(`{"code":0,"message":"ok","results":{"data":[]}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"app-protocols-terminals", "--appid", "2580003"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	terminalsCmd, _, err := cmd.Find([]string{"app-protocols-terminals"})
+	if err != nil {
+		t.Fatalf("Find() error = %v", err)
+	}
+	if got := terminalsCmd.Flags().Lookup("appid").Usage; got != "App protocol ID, e.g. 2580003 (required)" {
+		t.Fatalf("appid usage = %q", got)
 	}
 }
 

--- a/skills/monitor.md
+++ b/skills/monitor.md
@@ -12,24 +12,26 @@ All examples use `--format json` because this skill is primarily for agents and 
 ### System Overview
 ```bash
 ikuai-cli monitor system --format json       # Uptime, load, firmware version, WAN IP
-ikuai-cli monitor cpu --format json          # CPU load (default: last hour, avg)
-ikuai-cli monitor cpu --format json --time-range day --aggregate max   # Last day, max values
-ikuai-cli monitor memory --format json       # Memory usage history
-ikuai-cli monitor disk --format json         # Disk usage history
-ikuai-cli monitor temp --format json         # CPU temperature history
-ikuai-cli monitor connections --format json  # Connection count history
-ikuai-cli monitor terminals --format json    # Terminal count history
-ikuai-cli monitor network-load --format json # Network load history
+ikuai-cli monitor cpu --format json --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor cpu --format json --time-range day --start-time 1773215100 --end-time 1773301500 --aggregate max
+ikuai-cli monitor memory --format json --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor disk --format json --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor temp --format json --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor connections --format json --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor terminals --format json --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor network-load --format json --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
 ```
 
 Load commands (cpu, memory, disk, temp, terminals, connections, network-load) support:
 - `--time-range hour|day|week|month` — time range
+- `--start-time <unix>` — start timestamp
+- `--end-time <unix>` — end timestamp
 - `--aggregate avg|max` — calculation method
 
 ### Traffic & Network
 ```bash
-ikuai-cli monitor network-load --format json         # Overall network load + rate history
-ikuai-cli monitor downstream --format json           # Downstream traffic detail
+ikuai-cli monitor network-load --format json --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor downstream --format json --page 1 --page-size 20 --device camera --status 1
 ikuai-cli monitor interfaces --format json           # WAN interface status (IP, gateway)
 ikuai-cli monitor interfaces-traffic --format json   # Per-interface Bytes/s
 ikuai-cli monitor interfaces-config --format json    # Interface config detail
@@ -51,17 +53,17 @@ ikuai-cli monitor traffic-summary --format json                             # Pe
 Per-client commands (require `--ip` and `--mac`):
 ```bash
 ikuai-cli monitor traffic-load --format json --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c
-ikuai-cli monitor client-protocols --format json --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c
-ikuai-cli monitor client-protocols-history --format json --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c
-ikuai-cli monitor client-app-protocols --format json --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c
+ikuai-cli monitor client-protocols --format json --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c --starttime 1773304236 --stoptime 1773304246
+ikuai-cli monitor client-protocols-history --format json --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c --starttime 1773304236 --stoptime 1773304246
+ikuai-cli monitor client-app-protocols --format json --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c --page-size 10
 ```
 
 ### Application & Protocol
 ```bash
 ikuai-cli monitor protocols --format json            # Protocol distribution
 ikuai-cli monitor protocols-history --format json    # Protocol history
-ikuai-cli monitor app-traffic-summary --format json  # App-layer traffic summary (24h)
-ikuai-cli monitor app-protocols-load --format json   # Current app protocol load
+ikuai-cli monitor app-traffic-summary --format json --page 1 --page-size 20  # App-layer traffic summary (24h)
+ikuai-cli monitor app-protocols-load --format json --page 1 --page-size 20 --order desc --order-by total_down  # Current app protocol load
 ikuai-cli monitor app-protocols-history --format json --appids 2580003,2580004 --starttime 1773215100 --stoptime 1773218700  # App protocol rate history
 ikuai-cli monitor app-protocols-terminals --format json --appid 2580003         # Terminals using an app
 ```
@@ -70,10 +72,10 @@ ikuai-cli monitor app-protocols-terminals --format json --appid 2580003         
 ```bash
 ikuai-cli monitor wireless-stats --format json    # Wireless site statistics
 ikuai-cli monitor wireless-score --format json    # Quality score
-ikuai-cli monitor wireless-traffic --format json  # Per-AP traffic
-ikuai-cli monitor ssid-clients --format json      # SSID client distribution
-ikuai-cli monitor channel-clients --format json   # Channel client distribution
-ikuai-cli monitor cameras --format json           # IP camera list
+ikuai-cli monitor wireless-traffic --format json --apmac 00:00:00:00:00:00
+ikuai-cli monitor ssid-clients --format json --ssid iKuai01_2G
+ikuai-cli monitor channel-clients --format json --channel 6
+ikuai-cli monitor cameras --format json --page 1 --page-size 20 --keyword Hikvision
 ```
 
 ## Common Workflows
@@ -81,10 +83,10 @@ ikuai-cli monitor cameras --format json           # IP camera list
 ### Health Check
 ```bash
 ikuai-cli monitor system --format json
-ikuai-cli monitor cpu --format json
-ikuai-cli monitor memory --format json
-ikuai-cli monitor disk --format json
-ikuai-cli monitor connections --format json
+ikuai-cli monitor cpu --format json --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor memory --format json --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor disk --format json --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
+ikuai-cli monitor connections --format json --time-range hour --start-time 1773300000 --end-time 1773303600 --aggregate avg
 ```
 
 ### Traffic Investigation
@@ -93,9 +95,10 @@ ikuai-cli monitor connections --format json
 ikuai-cli monitor clients-online --format json --page-size 200
 # Step 2: Drill into a specific client
 ikuai-cli monitor traffic-load --format json --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c
-ikuai-cli monitor client-protocols --format json --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c
-ikuai-cli monitor client-app-protocols --format json --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c
+ikuai-cli monitor client-protocols --format json --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c --starttime 1773304236 --stoptime 1773304246
+ikuai-cli monitor client-protocols-history --format json --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c --starttime 1773304236 --stoptime 1773304246
+ikuai-cli monitor client-app-protocols --format json --ip 192.168.1.100 --mac 08:9b:4b:01:7e:7c --page-size 10
 # Step 3: Check app-level traffic
-ikuai-cli monitor app-traffic-summary --format json
+ikuai-cli monitor app-traffic-summary --format json --page 1 --page-size 20
 ikuai-cli monitor app-protocols-terminals --format json --appid 2580003
 ```


### PR DESCRIPTION
## Summary

- Align monitor command flags and query serialization.
- Require load-history commands to provide the required time range parameters.
- Add coverage for monitor help text, required flag validation, pagination mapping, and query serialization.
- Update monitor examples in user reference docs and Agent-facing skill docs.