### PR TITLE
fix: align security terminals flags with api

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -154,12 +154,23 @@ ikuai-cli security acl list
 ikuai-cli security acl create --name "BlockSSH" --action drop --protocol tcp --direction forward --dst-port 22 --priority 30 --enabled no
 ikuai-cli security mac get-mode
 ikuai-cli security mac set-mode --acl-mac 0
+ikuai-cli security mac create --name "AllowPhone" --mac "00:11:22:33:44:55" --enabled no
+ikuai-cli security l7 create --name "BlockApp" --action drop --app-proto "抖音短视频" --priority 30 --enabled no
 ikuai-cli security url black list
+ikuai-cli security url black create --name "BlockAds" --mode 0 --domain "ads.example.com" --enabled no
 ikuai-cli security url keywords create --name "KW1" --mode exact --src-url "example.com" --ori-keyword "bad" --rep-keyword "good" --hit-rate 1 --priority 10 --enabled no
+ikuai-cli security url redirect create --name "Redirect1" --mode exact --src-url "old.example.com" --dst-url "192.0.2.10" --hit-rate 1 --priority 30 --enabled no
+ikuai-cli security url replace create --name "Replace1" --mode exact --src-url "example.com" --param-keyword "track" --rep-keyword "clean" --hit-rate 1 --priority 30 --enabled no
 ikuai-cli security domain-blacklist list
-ikuai-cli security l7 list
+ikuai-cli security domain-blacklist create --name "BlockedDomains" --domain-group "blocked_group" --enabled no
+ikuai-cli security peerconn list
+ikuai-cli security peerconn create --name "LimitConn" --limits 500 --protocol tcp --src-addr "192.168.1.0/24" --dst-port 65000 --enabled no
+ikuai-cli security terminals list
+ikuai-cli security terminals create --name "Printer" --mac "AA:BB:CC:DD:EE:FF" --comment "office"
 ikuai-cli security advanced-get
+ikuai-cli security advanced-set --noping-lan 1
 ikuai-cli security secondary-route-get
+ikuai-cli security secondary-route-set --ttl-num 21
 ```
 
 ## VPN

--- a/internal/cmd/security/behavior_test.go
+++ b/internal/cmd/security/behavior_test.go
@@ -179,6 +179,32 @@ func TestTerminalsDoesNotExposeToggle(t *testing.T) {
 	}
 }
 
+func TestTerminalsDoesNotExposeUnsupportedEnabledFlag(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "tok"}
+
+	cmd := New(app)
+	createCmd, _, err := cmd.Find([]string{"terminals", "create"})
+	if err != nil {
+		t.Fatalf("Find terminals create error = %v", err)
+	}
+	if flag := createCmd.Flags().Lookup("enabled"); flag != nil {
+		t.Fatal("terminals create should not expose --enabled")
+	}
+
+	updateCmd, _, err := cmd.Find([]string{"terminals", "update"})
+	if err != nil {
+		t.Fatalf("Find terminals update error = %v", err)
+	}
+	if flag := updateCmd.Flags().Lookup("enabled"); flag != nil {
+		t.Fatal("terminals update should not expose --enabled")
+	}
+}
+
 func TestACLCreateMissingRequiredFlags(t *testing.T) {
 	t.Parallel()
 	var out bytes.Buffer

--- a/internal/cmd/security/command.go
+++ b/internal/cmd/security/command.go
@@ -506,7 +506,9 @@ func secWriteCmd(app *cliapp.Runtime, use, short string, withID bool, fieldMap m
 
 	if fieldMap != nil {
 		addSemanticFlags(c, fieldMap, customFlagDescs)
-		cliapp.AddEnabledFlag(c)
+		if _, ok := fieldMap["enabled"]; ok {
+			cliapp.AddEnabledFlag(c)
+		}
 
 		c.RunE = func(cmd *cobra.Command, args []string) error {
 			if err := app.RequireAuth(); err != nil {


### PR DESCRIPTION
## Summary

- Align `security terminals create/update` flags with the security terminals YAML contract by no longer exposing unsupported `--enabled`.
- Add a regression test to ensure terminals create/update do not reintroduce `--enabled`.
- Update `docs/cli-reference.md` Security examples to cover peerconn, terminals, URL variants, and set commands without `--format json`.