### PR TITLE
test: complete objects command regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ ikuai-cli log system list --human-time       # System logs
 - **Users** — account management, auth-server, bandwidth limits
 - **Routing** — static routes, policy routing, multi-WAN
 - **VPN** — IPSec, PPTP, L2TP, WireGuard
+- **Objects** — IP, IPv6, MAC, port, protocol, domain, time object groups
 - **Wireless** — Wi-Fi configuration and management
 - **QoS** — bandwidth control and traffic shaping
 - **System** — config, schedules, remote access, VRRP, SSH-based reset
@@ -149,7 +150,7 @@ Environment variables (`IKUAI_CLI_BASE_URL` / `IKUAI_CLI_TOKEN`) are never writt
 
 ## Use with AI Agents
 
-ikuai-cli ships with a [`SKILL.md`](./SKILL.md) and 7 domain-specific [skills](./skills/) that teach AI agents how to manage iKuai routers.
+ikuai-cli ships with a [`SKILL.md`](./SKILL.md) and domain-specific [skills](./skills/) that teach AI agents how to manage iKuai routers.
 
 | Skill | Description |
 |-------|-------------|
@@ -158,6 +159,7 @@ ikuai-cli ships with a [`SKILL.md`](./SKILL.md) and 7 domain-specific [skills](.
 | [users](skills/users.md) | Online users, kick, accounts, packages |
 | [security](skills/security.md) | ACL, MAC filter, L7, URL filter, domain blacklist, peerconn, terminals |
 | [vpn](skills/vpn.md) | PPTP, L2TP, OpenVPN, IKEv2, IPSec, WireGuard |
+| [objects](skills/objects.md) | IP, IPv6, MAC, port, protocol, domain, time object groups |
 | [system](skills/system.md) | Config, schedules, remote access, VRRP, SSH reset |
 | [batch](skills/batch.md) | Multi-command workflows: init, bulk DHCP, backup |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -110,6 +110,7 @@ ikuai-cli log system list --human-time       # 系统日志
 - **用户管理** — 账号管理、认证服务器、带宽限制
 - **路由配置** — 静态路由、策略路由、多 WAN 负载均衡
 - **VPN** — IPSec、PPTP、L2TP、WireGuard
+- **对象组** — IP、IPv6、MAC、端口、协议、域名、时间对象组
 - **无线管理** — Wi-Fi 配置与管理
 - **QoS** — 带宽控制和流量整形
 - **系统维护** — 配置管理、定时任务、远程访问、VRRP、SSH 重置
@@ -149,7 +150,7 @@ export IKUAI_CLI_CONFIG_FILE=/path/to/config.json
 
 ## AI Agent 集成
 
-ikuai-cli 内置 [`SKILL.md`](./SKILL.md) 和 7 个领域 [skills](./skills/)，让 AI Agent 可以直接操作 iKuai 路由器。
+ikuai-cli 内置 [`SKILL.md`](./SKILL.md) 和领域 [skills](./skills/)，让 AI Agent 可以直接操作 iKuai 路由器。
 
 | 技能 | 说明 |
 |------|------|
@@ -158,6 +159,7 @@ ikuai-cli 内置 [`SKILL.md`](./SKILL.md) 和 7 个领域 [skills](./skills/)，
 | [users](skills/users.md) | 在线用户、踢下线、账户、套餐 |
 | [security](skills/security.md) | ACL、MAC 过滤、L7、URL 过滤、域名黑名单、连接数限制、终端标注 |
 | [vpn](skills/vpn.md) | PPTP、L2TP、OpenVPN、IKEv2、IPSec、WireGuard |
+| [objects](skills/objects.md) | IP、IPv6、MAC、端口、协议、域名、时间对象组 |
 | [system](skills/system.md) | 系统配置、定时任务、远程访问、VRRP、SSH 重置 |
 | [batch](skills/batch.md) | 组合工作流：初始化、批量 DHCP、配置备份 |
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -59,7 +59,7 @@ ikuai-cli auth status --format json
 | Auth | [auth.md](skills/auth.md) | Login, PPPoE auth accounts |
 | Auth Server | [auth-server.md](skills/auth-server.md) | Web portal auth config |
 | Log | [log.md](skills/log.md) | System/DHCP/PPPoE/auth/ARP logs |
-| Objects | [objects.md](skills/objects.md) | IP/MAC/port/domain/time objects |
+| Objects | [objects.md](skills/objects.md) | IP/IPv6/MAC/port/protocol/domain/time objects |
 | QoS | [qos.md](skills/qos.md) | IP/MAC bandwidth control |
 | Routing | [routing.md](skills/routing.md) | Static routes, stream shunting |
 | Wireless | [wireless.md](skills/wireless.md) | Blacklist, VLAN, AC management |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -17,16 +17,20 @@ ikuai-cli <resource> <action> [args] [flags]
     --human-time               # Convert timestamps to human-readable local time
 ```
 
-## List Flags
+## Common List Flags
 
-Common flags for all `list` commands:
+Most `list` commands support:
 
 ```bash
 -p, --page INT          # Page number (default: 1)
-    --page-size INT     # Items per page (default: 100)
--L, --limit INT         # Total items limit with auto-pagination
+    --page-size INT     # Items per page
+```
+
+Some list endpoints also support one or more of these flags. Check the command help before using them:
+
+```bash
     --filter STRING     # Filter expression, e.g. "enabled==true"
--o, --order-by STRING   # Sort field
+    --order-by STRING   # Sort field
     --order asc|desc    # Sort direction
 ```
 
@@ -320,19 +324,19 @@ ikuai-cli auth-server set --data '{"enabled":true}'
 ## Objects
 
 ```bash
-ikuai-cli objects ip list
+ikuai-cli objects ip list --page 1 --page-size 20
 ikuai-cli objects ip create --name servers --value 192.168.1.10,192.168.1.11
 ikuai-cli objects ip get <ID>
 ikuai-cli objects ip update <ID> --name servers_v2 --value 192.168.1.12
 ikuai-cli objects ip refs --group-name servers_v2
 ikuai-cli objects ip delete <ID> --yes
-ikuai-cli objects ip6 list
-ikuai-cli objects mac list
-ikuai-cli objects port list
-ikuai-cli objects proto list
-ikuai-cli objects domain list
+ikuai-cli objects ip6 list --page 1 --page-size 20
+ikuai-cli objects mac list --page 1 --page-size 20
+ikuai-cli objects port list --page 1 --page-size 20
+ikuai-cli objects proto list --page 1 --page-size 20
+ikuai-cli objects domain list --page 1 --page-size 20
 ikuai-cli objects time create --name office --type weekly --weekdays 12345 --start-time 09:00 --end-time 18:00
-ikuai-cli objects time list
+ikuai-cli objects time list --page 1 --page-size 20
 ```
 
 ## Other

--- a/internal/cmd/objects/behavior_test.go
+++ b/internal/cmd/objects/behavior_test.go
@@ -32,17 +32,13 @@ func TestIPListBuildsExpectedQueryParams(t *testing.T) {
 			if q.Get("page") != "4" {
 				t.Fatalf("page = %q, want %q", q.Get("page"), "4")
 			}
-			if q.Get("page_size") != "15" {
-				t.Fatalf("page_size = %q, want %q", q.Get("page_size"), "15")
+			if q.Get("limit") != "15" {
+				t.Fatalf("limit = %q, want %q", q.Get("limit"), "15")
 			}
-			if q.Get("filter") != "group==office" {
-				t.Fatalf("filter = %q, want %q", q.Get("filter"), "group==office")
-			}
-			if q.Get("order") != "asc" {
-				t.Fatalf("order = %q, want %q", q.Get("order"), "asc")
-			}
-			if q.Get("order_by") != "name" {
-				t.Fatalf("order_by = %q, want %q", q.Get("order_by"), "name")
+			for _, unsupported := range []string{"page_size", "filter", "order", "order_by"} {
+				if q.Has(unsupported) {
+					t.Fatalf("query unexpectedly includes %q: %v", unsupported, q)
+				}
 			}
 			if got := req.Header.Get("Authorization"); got != "Bearer token-obj" {
 				t.Fatalf("Authorization = %q, want %q", got, "Bearer token-obj")
@@ -52,7 +48,7 @@ func TestIPListBuildsExpectedQueryParams(t *testing.T) {
 	})
 
 	cmd := New(app)
-	cmd.SetArgs([]string{"ip", "list", "--page", "4", "--page-size", "15", "--filter", "group==office", "--order", "asc", "--order-by", "name"})
+	cmd.SetArgs([]string{"ip", "list", "--page", "4", "--page-size", "15"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -169,6 +165,33 @@ func TestObjectCommandsDoNotExposeUnsupportedToggle(t *testing.T) {
 
 	if strings.Contains(out.String(), "toggle") {
 		t.Fatalf("help unexpectedly exposes toggle: %s", out.String())
+	}
+}
+
+func TestObjectListDoesNotExposeUnsupportedQueryFlags(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	cmd := New(app)
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"ip", "list", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	help := out.String()
+	for _, unsupported := range []string{"--filter", "--order ", "--order-by"} {
+		if strings.Contains(help, unsupported) {
+			t.Fatalf("help unexpectedly exposes %s: %s", unsupported, help)
+		}
+	}
+	for _, expected := range []string{"--page", "--page-size"} {
+		if !strings.Contains(help, expected) {
+			t.Fatalf("help missing %s: %s", expected, help)
+		}
 	}
 }
 

--- a/internal/cmd/objects/command.go
+++ b/internal/cmd/objects/command.go
@@ -42,9 +42,10 @@ func objectGroup(app *cliapp.Runtime, name, apiPath string, fieldMap map[string]
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
-			page, pageSize, filter, order, orderBy := cliapp.GetListParams(cmd)
+			page, _ := cmd.Flags().GetInt("page")
+			pageSize, _ := cmd.Flags().GetInt("page-size")
 			raw, err := app.APIClient.Get(cliapp.APIBase+"/"+apiPath,
-				cliapp.ListParams(page, pageSize, filter, order, orderBy))
+				cliapp.ListParamsWithPageSizeKey(page, pageSize, "", "", "", "limit"))
 			if err != nil {
 				return err
 			}
@@ -52,7 +53,7 @@ func objectGroup(app *cliapp.Runtime, name, apiPath string, fieldMap map[string]
 			return nil
 		},
 	}
-	cliapp.AddListFlags(listCmd)
+	cliapp.AddPaginationFlags(listCmd)
 
 	getCmd := &cobra.Command{
 		Use:   "get ID",

--- a/skills/objects.md
+++ b/skills/objects.md
@@ -11,8 +11,8 @@ description: iKuai network objects — IP, IPv6, MAC, port, protocol, domain, ti
 
 ```bash
 # List
-ikuai-cli objects ip list --format json
-ikuai-cli objects mac list --format json
+ikuai-cli objects ip list --page 1 --page-size 20 --format json
+ikuai-cli objects mac list --page 1 --page-size 20 --format json
 
 # Create（--value 逗号分隔，自动转为 group_value 数组）
 ikuai-cli objects ip create --name "servers" --value "192.168.1.10,192.168.1.11" --format json
@@ -34,5 +34,7 @@ ikuai-cli objects ip delete <ID> --yes --format json
 # 查看引用该对象的规则
 ikuai-cli objects ip refs --group-name "servers" --format json
 ```
+
+List 仅支持 `--page/--page-size`；不支持 `--filter`、`--order`、`--order-by`。
 
 复杂对象内容仍可用 `--data` 传完整 JSON body。


### PR DESCRIPTION
## Summary

- Aligned objects list commands with the object_group YAML API by exposing only pagination flags and sending `page/limit` query params.
- Added regression-focused tests for objects list query params and help output.
- Updated objects docs, README entries, root skill, and agent-facing objects skill to match current CLI behavior.