### PR TITLE
fix: show app id and name in client app protocols

### DIFF
--- a/internal/cmd/monitor/command.go
+++ b/internal/cmd/monitor/command.go
@@ -387,7 +387,7 @@ func monitorClientAppProtocolsCmd(app *cliapp.Runtime) *cobra.Command {
 			}
 			ip, _ := cmd.Flags().GetString("ip")
 			mac, _ := cmd.Flags().GetString("mac")
-			app.DefaultColumns = []string{"id", "app_name", "conn_cnt", "upload", "download", "total"}
+			app.DefaultColumns = []string{"id", "appid", "appname", "conn_cnt", "upload", "download", "total"}
 			params := map[string]string{"ip": ip, "mac": mac}
 			if limit, _ := cmd.Flags().GetInt("page-size"); limit > 0 {
 				params["limit"] = intStr(limit)

--- a/internal/cmd/monitor/command_test.go
+++ b/internal/cmd/monitor/command_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/ikuaidev/ikuai-cli/internal/api"
@@ -498,6 +499,40 @@ func TestClientAppProtocolsPassesYamlLimit(t *testing.T) {
 	cmd.SetArgs([]string{"client-app-protocols", "--ip", "192.168.9.199", "--mac", "08:9b:4b:01:7e:7c", "--page-size", "10"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestClientAppProtocolsDefaultTableUsesReturnedAppnameField(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.Table
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-123"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/api/v4.0/monitoring/clients/app-protocols/load" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/monitoring/clients/app-protocols/load")
+			}
+			return jsonResponse(`{"code":0,"message":"ok","data":[{"id":1,"appid":12345,"appname":"ChatGPT","conn_cnt":2,"upload":3,"download":4,"total":7}]}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"client-app-protocols", "--ip", "192.168.9.199", "--mac", "08:9b:4b:01:7e:7c", "--page-size", "10"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "APPID") || !strings.Contains(got, "12345") {
+		t.Fatalf("default table should show appid value: %q", got)
+	}
+	if !strings.Contains(got, "APPNAME") || !strings.Contains(got, "ChatGPT") {
+		t.Fatalf("default table should show appname value: %q", got)
+	}
+	if strings.Contains(got, "APP_NAME") {
+		t.Fatalf("default table should not use stale app_name column: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixed `monitor client-app-protocols` default TTY output to use the real `appname` response field.
- Added `appid` to the default client app protocols table for easier protocol identification.
- Added a regression test covering the default table columns and values.