### PR TITLE
fix(vpn): align list pagination and search flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ ikuai-cli log system list --human-time       # System logs
 - **Security** — ACL, MAC filtering, L7 rules, URL filtering, domain blacklist, peerconn, terminals
 - **Users** — account management, auth-server, bandwidth limits
 - **Routing** — static routes, policy routing, multi-WAN
-- **VPN** — IPSec, PPTP, L2TP, WireGuard
+- **VPN** — PPTP, L2TP, OpenVPN, IKEv2, IPSec, WireGuard
 - **Objects** — IP, IPv6, MAC, port, protocol, domain, time object groups
 - **Wireless** — Wi-Fi configuration and management
 - **QoS** — bandwidth control and traffic shaping

--- a/README_CN.md
+++ b/README_CN.md
@@ -109,7 +109,7 @@ ikuai-cli log system list --human-time       # 系统日志
 - **安全策略** — ACL、MAC 过滤、L7 规则、URL 过滤、域名黑名单、连接数限制、终端标注
 - **用户管理** — 账号管理、认证服务器、带宽限制
 - **路由配置** — 静态路由、策略路由、多 WAN 负载均衡
-- **VPN** — IPSec、PPTP、L2TP、WireGuard
+- **VPN** — PPTP、L2TP、OpenVPN、IKEv2、IPSec、WireGuard
 - **对象组** — IP、IPv6、MAC、端口、协议、域名、时间对象组
 - **无线管理** — Wi-Fi 配置与管理
 - **QoS** — 带宽控制和流量整形

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -182,6 +182,7 @@ ikuai-cli security secondary-route-set --ttl-num 21
 ```bash
 ikuai-cli vpn pptp get
 ikuai-cli vpn pptp clients
+ikuai-cli vpn pptp clients --key name --pattern pptpoffice
 ikuai-cli vpn pptp client-create --name pptpoffice --server vpn.example.com --username user1 --password 123456 --interface auto --enabled no
 ikuai-cli vpn pptp client-get <ID>
 ikuai-cli vpn pptp client-update <ID> --comment updated
@@ -190,19 +191,24 @@ ikuai-cli vpn pptp client-delete <ID> --yes
 ikuai-cli vpn l2tp get
 ikuai-cli vpn l2tp clients
 ikuai-cli vpn openvpn get
+ikuai-cli vpn openvpn clients --key name --pattern ovpnoffice
 ikuai-cli vpn openvpn client-create --name ovpnoffice --remote-addr vpn.example.com --username user1 --password 123456 --ca "<CA证书>" --interface auto --enabled no
 ikuai-cli vpn ikev2 get
+ikuai-cli vpn ikev2 clients --key name --pattern ikedoffice
 ikuai-cli vpn ikev2 client-create --name ikedoffice --remote-addr vpn.example.com --interface auto --left-id localid --username user1 --password 123456 --enabled no
 ikuai-cli vpn ipsec clients
+ikuai-cli vpn ipsec clients --key name --pattern ipsecsite
 ikuai-cli vpn ipsec client-create --name ipsecsite --remote-addr 10.0.0.1 --interface wan1 --left-subnet 192.168.1.0/24 --right-subnet 192.168.2.0/24 --secret psk123 --enabled no
 ikuai-cli vpn ipsec client-get <ID>
 ikuai-cli vpn ipsec client-update <ID> --comment updated
 ikuai-cli vpn ipsec client-toggle <ID> --enabled no
 ikuai-cli vpn ipsec client-delete <ID> --yes
 ikuai-cli vpn wireguard list
+ikuai-cli vpn wireguard list --key name --pattern wgsite
 ikuai-cli vpn wireguard create --name wgsite --address 10.9.0.1/24 --interface auto --private-key "<base64>" --public-key "<base64>" --enabled no
 ikuai-cli vpn wireguard update <ID> --interface auto --port 5001
 ikuai-cli vpn wireguard peers <ID>
+ikuai-cli vpn wireguard peers <ID> --key interface --pattern wgsite
 ikuai-cli vpn wireguard peer-create <ID> --public-key "<base64>" --allow-ips 10.9.0.2/32 --interface wgsite --enabled no
 ikuai-cli vpn wireguard peer-get <ID> <PEER_ID>
 ikuai-cli vpn wireguard peer-update <ID> <PEER_ID> --interface wgsite --comment updated

--- a/internal/cmd/vpn/behavior_test.go
+++ b/internal/cmd/vpn/behavior_test.go
@@ -32,8 +32,11 @@ func TestOpenVPNClientsBuildExpectedQueryParams(t *testing.T) {
 			if q.Get("page") != "2" {
 				t.Fatalf("page = %q, want %q", q.Get("page"), "2")
 			}
-			if q.Get("page_size") != "16" {
-				t.Fatalf("page_size = %q, want %q", q.Get("page_size"), "16")
+			if q.Get("limit") != "16" {
+				t.Fatalf("limit = %q, want %q", q.Get("limit"), "16")
+			}
+			if q.Get("page_size") != "" {
+				t.Fatalf("page_size = %q, want empty", q.Get("page_size"))
 			}
 			if q.Get("filter") != "enabled==yes" {
 				t.Fatalf("filter = %q, want %q", q.Get("filter"), "enabled==yes")
@@ -44,6 +47,12 @@ func TestOpenVPNClientsBuildExpectedQueryParams(t *testing.T) {
 			if q.Get("order_by") != "username" {
 				t.Fatalf("order_by = %q, want %q", q.Get("order_by"), "username")
 			}
+			if q.Get("key") != "name,username" {
+				t.Fatalf("key = %q, want %q", q.Get("key"), "name,username")
+			}
+			if q.Get("pattern") != "ovpn" {
+				t.Fatalf("pattern = %q, want %q", q.Get("pattern"), "ovpn")
+			}
 			if got := req.Header.Get("Authorization"); got != "Bearer token-vpn" {
 				t.Fatalf("Authorization = %q, want %q", got, "Bearer token-vpn")
 			}
@@ -52,7 +61,7 @@ func TestOpenVPNClientsBuildExpectedQueryParams(t *testing.T) {
 	})
 
 	cmd := New(app)
-	cmd.SetArgs([]string{"openvpn", "clients", "--page", "2", "--page-size", "16", "--filter", "enabled==yes", "--order", "asc", "--order-by", "username"})
+	cmd.SetArgs([]string{"openvpn", "clients", "--page", "2", "--page-size", "16", "--filter", "enabled==yes", "--order", "asc", "--order-by", "username", "--key", "name,username", "--pattern", "ovpn"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -61,6 +70,24 @@ func TestOpenVPNClientsBuildExpectedQueryParams(t *testing.T) {
 	want := `{"items":[]}` + "\n"
 	if got != want {
 		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestVPNListExposesYamlSearchParameters(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+
+	cmd := New(app)
+	clientsCmd, _, err := cmd.Find([]string{"pptp", "clients"})
+	if err != nil {
+		t.Fatalf("Find() error = %v", err)
+	}
+	for _, name := range []string{"page", "page-size", "filter", "order", "order-by", "key", "pattern"} {
+		if clientsCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("expected flag %q to exist", name)
+		}
 	}
 }
 

--- a/internal/cmd/vpn/command.go
+++ b/internal/cmd/vpn/command.go
@@ -377,8 +377,9 @@ func vpnServerGroup(app *cliapp.Runtime, name, apiPath string, clientFieldMap ma
 				app.DefaultColumns = defaultColumns
 			}
 			page, pageSize, filter, order, orderBy := cliapp.GetListParams(cmd)
+			params := vpnListParams(cmd, page, pageSize, filter, order, orderBy)
 			raw, err := app.APIClient.Get(cliapp.APIBase+"/"+apiPath+"/clients",
-				cliapp.ListParams(page, pageSize, filter, order, orderBy))
+				params)
 			if err != nil {
 				return err
 			}
@@ -386,7 +387,7 @@ func vpnServerGroup(app *cliapp.Runtime, name, apiPath string, clientFieldMap ma
 			return nil
 		},
 	}
-	cliapp.AddListFlags(clientsCmd)
+	addVPNListFlags(clientsCmd)
 
 	clientCreateCmd := writeCmd(app, "client-create", "Create a "+name+" client", false, clientFieldMap, nil, clientDefaults,
 		func(body interface{}, id string) (json.RawMessage, error) {
@@ -415,6 +416,23 @@ func vpnServerGroup(app *cliapp.Runtime, name, apiPath string, clientFieldMap ma
 	return grp
 }
 
+func addVPNListFlags(cmd *cobra.Command) {
+	cliapp.AddListFlags(cmd)
+	cmd.Flags().String("key", "", "Fuzzy match fields, comma-separated")
+	cmd.Flags().String("pattern", "", "Fuzzy match pattern")
+}
+
+func vpnListParams(cmd *cobra.Command, page, pageSize int, filter, order, orderBy string) map[string]string {
+	params := cliapp.ListParamsWithPageSizeKey(page, pageSize, filter, order, orderBy, "limit")
+	if key, _ := cmd.Flags().GetString("key"); key != "" {
+		params["key"] = key
+	}
+	if pattern, _ := cmd.Flags().GetString("pattern"); pattern != "" {
+		params["pattern"] = pattern
+	}
+	return params
+}
+
 func ipsecGroup(app *cliapp.Runtime) *cobra.Command {
 	grp := &cobra.Command{Use: "ipsec", Short: "IPSec clients"}
 
@@ -427,8 +445,9 @@ func ipsecGroup(app *cliapp.Runtime) *cobra.Command {
 			}
 			app.DefaultColumns = []string{"id", "name", "remote_addr", "leftsubnet", "rightsubnet", "interface", "keyexchange", "authby", "enabled"}
 			page, pageSize, filter, order, orderBy := cliapp.GetListParams(cmd)
+			params := vpnListParams(cmd, page, pageSize, filter, order, orderBy)
 			raw, err := app.APIClient.Get(cliapp.APIBase+"/vpn/ipsec/clients",
-				cliapp.ListParams(page, pageSize, filter, order, orderBy))
+				params)
 			if err != nil {
 				return err
 			}
@@ -436,7 +455,7 @@ func ipsecGroup(app *cliapp.Runtime) *cobra.Command {
 			return nil
 		},
 	}
-	cliapp.AddListFlags(clientsCmd)
+	addVPNListFlags(clientsCmd)
 
 	createCmd := writeCmd(app, "client-create", "Create an IPSec client", false, ipsecClientFieldMap, nil, ipsecClientDefaults,
 		func(body interface{}, id string) (json.RawMessage, error) {
@@ -480,8 +499,9 @@ func wireguardGroup(app *cliapp.Runtime) *cobra.Command {
 			}
 			app.DefaultColumns = []string{"id", "name", "local_address", "local_listenport", "interface", "mtu", "enabled"}
 			page, pageSize, filter, order, orderBy := cliapp.GetListParams(cmd)
+			params := vpnListParams(cmd, page, pageSize, filter, order, orderBy)
 			raw, err := app.APIClient.Get(cliapp.APIBase+"/vpn/wireguard",
-				cliapp.ListParams(page, pageSize, filter, order, orderBy))
+				params)
 			if err != nil {
 				return err
 			}
@@ -489,7 +509,7 @@ func wireguardGroup(app *cliapp.Runtime) *cobra.Command {
 			return nil
 		},
 	}
-	cliapp.AddListFlags(listCmd)
+	addVPNListFlags(listCmd)
 
 	peersListCmd := &cobra.Command{
 		Use:   "peers ID",
@@ -500,8 +520,9 @@ func wireguardGroup(app *cliapp.Runtime) *cobra.Command {
 				return err
 			}
 			page, pageSize, filter, order, orderBy := cliapp.GetListParams(cmd)
+			params := vpnListParams(cmd, page, pageSize, filter, order, orderBy)
 			raw, err := app.APIClient.Get(cliapp.APIBase+"/vpn/wireguard/"+args[0]+"/peers",
-				cliapp.ListParams(page, pageSize, filter, order, orderBy))
+				params)
 			if err != nil {
 				return err
 			}
@@ -509,7 +530,7 @@ func wireguardGroup(app *cliapp.Runtime) *cobra.Command {
 			return nil
 		},
 	}
-	cliapp.AddListFlags(peersListCmd)
+	addVPNListFlags(peersListCmd)
 
 	// WireGuard tunnel needs private/public keys — these must be passed via flags.
 	wgCreateFieldMap := make(map[string]string, len(wireguardFieldMap)+2)

--- a/skills/vpn.md
+++ b/skills/vpn.md
@@ -14,6 +14,7 @@ ikuai-cli vpn pptp set --enabled no --format json
 
 # 客户端 CRUD
 ikuai-cli vpn pptp clients --format json
+ikuai-cli vpn pptp clients --key name --pattern pptpoffice --format json
 ikuai-cli vpn pptp client-create --name pptpoffice --server "vpn.example.com" --username user1 --password "123456" --interface auto --enabled no --format json
 ikuai-cli vpn pptp client-get <ID> --format json
 ikuai-cli vpn pptp client-update <ID> --server "vpn2.example.com" --format json
@@ -22,7 +23,7 @@ ikuai-cli vpn pptp client-delete <ID> --yes --format json
 ikuai-cli vpn pptp kick <ID> --yes --format json
 ```
 
-L2TP 命令同理：`vpn l2tp get/set/clients/client-create/client-get/client-update/client-toggle/client-delete/kick`。L2TP 客户端 name 需以 `l2tp` 开头。
+L2TP 命令同理：`vpn l2tp get/set/clients/client-create/client-get/client-update/client-toggle/client-delete/kick`。PPTP/L2TP clients 支持 `--key/--pattern` 模糊搜索；L2TP 客户端 name 需以 `l2tp` 开头。
 
 ## OpenVPN
 
@@ -30,6 +31,7 @@ L2TP 命令同理：`vpn l2tp get/set/clients/client-create/client-get/client-up
 ikuai-cli vpn openvpn get --format json
 ikuai-cli vpn openvpn set --enabled no --format json
 ikuai-cli vpn openvpn clients --format json
+ikuai-cli vpn openvpn clients --key name --pattern ovpnoffice --format json
 ikuai-cli vpn openvpn client-create --name ovpnoffice --remote-addr "vpn.example.com" --username user1 --password "123456" --ca "<CA证书>" --interface auto --enabled no --format json
 ikuai-cli vpn openvpn client-get <ID> --format json
 ikuai-cli vpn openvpn client-update <ID> --comment "updated" --format json
@@ -46,6 +48,7 @@ ikuai-cli vpn openvpn kick <ID> --yes --format json
 ikuai-cli vpn ikev2 get --format json
 ikuai-cli vpn ikev2 set --enabled no --format json
 ikuai-cli vpn ikev2 clients --format json
+ikuai-cli vpn ikev2 clients --key name --pattern ikedoffice --format json
 ikuai-cli vpn ikev2 client-create --name ikedoffice --remote-addr "vpn.example.com" --interface auto --left-id "localid" --username user1 --password "123456" --enabled no --format json
 ikuai-cli vpn ikev2 client-get <ID> --format json
 ikuai-cli vpn ikev2 client-update <ID> --comment "updated" --format json
@@ -60,6 +63,7 @@ name 需以 `iked` 开头，authby=mschapv2 时 username 必填。
 
 ```bash
 ikuai-cli vpn ipsec clients --format json
+ikuai-cli vpn ipsec clients --key name --pattern ipsecsite --format json
 ikuai-cli vpn ipsec client-create --name ipsecsite --remote-addr "10.0.0.1" --interface wan1 --left-subnet "192.168.1.0/24" --right-subnet "192.168.2.0/24" --secret "psk123" --enabled no --format json
 ikuai-cli vpn ipsec client-get <ID> --format json
 ikuai-cli vpn ipsec client-update <ID> --comment "updated" --format json
@@ -74,6 +78,7 @@ ikuai-cli vpn ipsec kick <ID> --yes --format json
 ```bash
 # 隧道
 ikuai-cli vpn wireguard list --format json
+ikuai-cli vpn wireguard list --key name --pattern wgsite --format json
 ikuai-cli vpn wireguard create --name wgsite --address "10.9.0.1/24" --interface auto --private-key "<base64>" --public-key "<base64>" --enabled no --format json
 # defaults: interface=auto, port=5000, mtu=1420
 ikuai-cli vpn wireguard get <ID> --format json
@@ -83,6 +88,7 @@ ikuai-cli vpn wireguard delete <ID> --yes --format json
 
 # 对端
 ikuai-cli vpn wireguard peers <TUNNEL_ID> --format json
+ikuai-cli vpn wireguard peers <TUNNEL_ID> --key interface --pattern wgsite --format json
 ikuai-cli vpn wireguard peer-create <TUNNEL_ID> --public-key "<base64>" --allow-ips "10.9.0.2/32" --interface wgsite --enabled no --format json
 ikuai-cli vpn wireguard peer-get <TUNNEL_ID> <PEER_ID> --format json
 ikuai-cli vpn wireguard peer-update <TUNNEL_ID> <PEER_ID> --interface wgsite --comment "updated" --format json


### PR DESCRIPTION
## Summary
- Fix VPN list pagination behavior and add search flags across client and WireGuard list commands.
- Update VPN command tests and user-facing command examples.