### PR TITLE
fix(log): align log commands with standard actions

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -285,6 +285,7 @@ ikuai-cli log auth list
 ikuai-cli log dhcp list
 ikuai-cli log web list
 ikuai-cli log wireless list
+ikuai-cli log system delete --yes
 ```
 
 ## Wireless

--- a/internal/cmd/log/behavior_test.go
+++ b/internal/cmd/log/behavior_test.go
@@ -28,15 +28,28 @@ func TestSystemLogBuildsExpectedQueryParams(t *testing.T) {
 				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/log/system")
 			}
 			q := req.URL.Query()
-			if q.Get("page") != "3" || q.Get("page_size") != "9" || q.Get("filter") != "level==error" || q.Get("order") != "desc" || q.Get("order_by") != "time" {
-				t.Fatalf("unexpected query params: %s", req.URL.RawQuery)
+			for name, want := range map[string]string{
+				"page":     "3",
+				"limit":    "9",
+				"filter":   "level==error",
+				"key":      "level,module",
+				"pattern":  "error",
+				"order":    "desc",
+				"order_by": "timestamp",
+			} {
+				if got := q.Get(name); got != want {
+					t.Fatalf("%s = %q, want %q; raw=%s", name, got, want, req.URL.RawQuery)
+				}
+			}
+			if q.Get("page_size") != "" {
+				t.Fatalf("page_size = %q, want empty; raw=%s", q.Get("page_size"), req.URL.RawQuery)
 			}
 			return jsonResponse(`{"code":0,"data":{"items":[]}}`), nil
 		}),
 	})
 
 	cmd := New(app)
-	cmd.SetArgs([]string{"system", "--page", "3", "--page-size", "9", "--filter", "level==error", "--order", "desc", "--order-by", "time"})
+	cmd.SetArgs([]string{"system", "list", "--page", "3", "--page-size", "9", "--filter", "level==error", "--key", "level,module", "--pattern", "error", "--order", "desc", "--order-by", "timestamp"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -68,7 +81,7 @@ func TestSystemLogClearRequestsDelete(t *testing.T) {
 	})
 
 	cmd := New(app)
-	cmd.SetArgs([]string{"system-clear"})
+	cmd.SetArgs([]string{"system", "delete", "--yes"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -77,6 +90,27 @@ func TestSystemLogClearRequestsDelete(t *testing.T) {
 	want := "{\"message\":\"cleared\"}\n"
 	if got != want {
 		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestSystemLogDeleteRequiresYes(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-log"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected HTTP request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"system", "delete"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute() error = nil, want confirmation error")
 	}
 }
 

--- a/internal/cmd/log/command.go
+++ b/internal/cmd/log/command.go
@@ -5,44 +5,57 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type logResource struct {
+	name           string
+	apiPath        string
+	defaultColumns []string
+}
+
+var logResources = []logResource{
+	{name: "arp", apiPath: "log/arp", defaultColumns: []string{"id", "timestamp", "content"}},
+	{name: "auth", apiPath: "log/auth", defaultColumns: []string{"id", "timestamp", "username", "macip", "ppptype", "result", "ip_addr", "event", "interface"}},
+	{name: "dhcp", apiPath: "log/dhcp", defaultColumns: []string{"id", "timestamp", "msgtype", "interface", "ip_addr", "mac", "hostname"}},
+	{name: "pppoe", apiPath: "log/pppoe", defaultColumns: []string{"id", "timestamp", "interface", "content"}},
+	{name: "system", apiPath: "log/system", defaultColumns: []string{"id", "timestamp", "content"}},
+	{name: "web", apiPath: "log/web_activity", defaultColumns: []string{"id", "timestamp", "username", "ip_addr", "function", "event"}},
+	{name: "ddns", apiPath: "log/ddns", defaultColumns: []string{"id", "timestamp", "domain", "status", "ip_addr", "message"}},
+	{name: "notice", apiPath: "log/notice", defaultColumns: []string{"id", "timestamp", "type", "title", "content"}},
+	{name: "wireless", apiPath: "log/wireless", defaultColumns: []string{"id", "timestamp", "action", "mac", "apmac", "ssid", "errmsg", "signal"}},
+}
+
 func New(app *cliapp.Runtime) *cobra.Command {
 	logCmd := &cobra.Command{
 		Use:   "log",
 		Short: "System logs",
 	}
 
-	logCmd.AddCommand(flatLogListCmd(app, "arp", "log/arp"))
-	logCmd.AddCommand(flatLogClearCmd(app, "arp", "log/arp"))
-	logCmd.AddCommand(flatLogListCmd(app, "auth", "log/auth"))
-	logCmd.AddCommand(flatLogClearCmd(app, "auth", "log/auth"))
-	logCmd.AddCommand(flatLogListCmd(app, "dhcp", "log/dhcp"))
-	logCmd.AddCommand(flatLogClearCmd(app, "dhcp", "log/dhcp"))
-	logCmd.AddCommand(flatLogListCmd(app, "pppoe", "log/pppoe"))
-	logCmd.AddCommand(flatLogClearCmd(app, "pppoe", "log/pppoe"))
-	logCmd.AddCommand(flatLogListCmd(app, "system", "log/system"))
-	logCmd.AddCommand(flatLogClearCmd(app, "system", "log/system"))
-	logCmd.AddCommand(flatLogListCmd(app, "web", "log/web_activity"))
-	logCmd.AddCommand(flatLogClearCmd(app, "web", "log/web_activity"))
-	logCmd.AddCommand(flatLogListCmd(app, "ddns", "log/ddns"))
-	logCmd.AddCommand(flatLogClearCmd(app, "ddns", "log/ddns"))
-	logCmd.AddCommand(flatLogListCmd(app, "notice", "log/notice"))
-	logCmd.AddCommand(flatLogClearCmd(app, "notice", "log/notice"))
-	logCmd.AddCommand(flatLogListCmd(app, "wireless", "log/wireless"))
-	logCmd.AddCommand(flatLogClearCmd(app, "wireless", "log/wireless"))
+	for _, resource := range logResources {
+		logCmd.AddCommand(logGroup(app, resource))
+	}
 	return logCmd
 }
 
-func flatLogListCmd(app *cliapp.Runtime, name, apiPath string) *cobra.Command {
+func logGroup(app *cliapp.Runtime, resource logResource) *cobra.Command {
+	group := &cobra.Command{
+		Use:   resource.name,
+		Short: resource.name + " log",
+	}
+	group.AddCommand(logListCmd(app, resource))
+	group.AddCommand(logDeleteCmd(app, resource))
+	return group
+}
+
+func logListCmd(app *cliapp.Runtime, resource logResource) *cobra.Command {
 	c := &cobra.Command{
-		Use:   name,
-		Short: "Show " + name + " log",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List " + resource.name + " logs",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
-			page, pageSize, filter, order, orderBy := cliapp.GetListParams(cmd)
-			raw, err := app.APIClient.Get(cliapp.APIBase+"/"+apiPath,
-				cliapp.ListParams(page, pageSize, filter, order, orderBy))
+			app.DefaultColumns = resource.defaultColumns
+			raw, err := app.APIClient.Get(cliapp.APIBase+"/"+resource.apiPath, logListParams(cmd))
 			if err != nil {
 				return err
 			}
@@ -50,19 +63,24 @@ func flatLogListCmd(app *cliapp.Runtime, name, apiPath string) *cobra.Command {
 			return nil
 		},
 	}
-	cliapp.AddListFlags(c)
+	addLogListFlags(c)
 	return c
 }
 
-func flatLogClearCmd(app *cliapp.Runtime, name, apiPath string) *cobra.Command {
-	return &cobra.Command{
-		Use:   name + "-clear",
-		Short: "Clear " + name + " log",
+func logDeleteCmd(app *cliapp.Runtime, resource logResource) *cobra.Command {
+	c := &cobra.Command{
+		Use:     "delete",
+		Aliases: []string{"clear"},
+		Short:   "Clear " + resource.name + " logs",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
-			raw, err := app.APIClient.Delete(cliapp.APIBase + "/" + apiPath)
+			yes, _ := cmd.Flags().GetBool("yes")
+			if err := cliapp.ConfirmDelete(app.Stdout, app.Stderr, resource.name+" logs", "all", yes); err != nil {
+				return err
+			}
+			raw, err := app.APIClient.Delete(cliapp.APIBase + "/" + resource.apiPath)
 			if err != nil {
 				return err
 			}
@@ -70,4 +88,36 @@ func flatLogClearCmd(app *cliapp.Runtime, name, apiPath string) *cobra.Command {
 			return nil
 		},
 	}
+	c.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	return c
+}
+
+func addLogListFlags(cmd *cobra.Command) {
+	cliapp.AddPaginationFlags(cmd)
+	cmd.Flags().String("filter", "", "Filter expression")
+	cmd.Flags().String("key", "", "Fields for fuzzy search")
+	cmd.Flags().String("pattern", "", "Fuzzy search pattern")
+	cmd.Flags().String("order", "", "Sort direction: asc|desc")
+	cmd.Flags().String("order-by", "", "Sort field")
+	_ = cmd.RegisterFlagCompletionFunc("order", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"asc", "desc"}, cobra.ShellCompDirectiveNoFileComp
+	})
+}
+
+func logListParams(cmd *cobra.Command) map[string]string {
+	page, _ := cmd.Flags().GetInt("page")
+	pageSize, _ := cmd.Flags().GetInt("page-size")
+	params := cliapp.ListParamsWithPageSizeKey(page, pageSize, "", "", "", "limit")
+	for _, name := range []string{"filter", "key", "pattern", "order", "order-by"} {
+		value, _ := cmd.Flags().GetString(name)
+		if value == "" {
+			continue
+		}
+		apiName := name
+		if name == "order-by" {
+			apiName = "order_by"
+		}
+		params[apiName] = value
+	}
+	return params
 }

--- a/skills/log.md
+++ b/skills/log.md
@@ -5,22 +5,22 @@ description: iKuai system logs — view and clear 9 types of logs (system, arp, 
 
 # Log
 
-9 种日志，每种有 list + clear：
+9 种日志，每种有 list + delete：
 
 ```bash
-# 查看（支持 --page, --page-size, --filter, --human-time）
-ikuai-cli log system --human-time
-ikuai-cli log arp
-ikuai-cli log auth
-ikuai-cli log dhcp
-ikuai-cli log pppoe
-ikuai-cli log web
-ikuai-cli log ddns
-ikuai-cli log notice
-ikuai-cli log wireless
+# 查看（支持 --page, --page-size, --filter, --key, --pattern, --human-time）
+ikuai-cli log system list --format json
+ikuai-cli log arp list --format json
+ikuai-cli log auth list --format json
+ikuai-cli log dhcp list --format json
+ikuai-cli log pppoe list --format json
+ikuai-cli log web list --format json
+ikuai-cli log ddns list --format json
+ikuai-cli log notice list --format json
+ikuai-cli log wireless list --format json
 
 # 清除（破坏性操作）
-ikuai-cli log system-clear
-ikuai-cli log dhcp-clear
-# ... 同理其他 <type>-clear
+ikuai-cli log system delete --yes --format json
+ikuai-cli log dhcp delete --yes --format json
+# ... 同理其他 <type> delete
 ```


### PR DESCRIPTION
## Summary

- Updated log commands to use `log <type> list` and `log <type> delete --yes`.
- Added log search flags and fixed page-size handling for log lists.
- Refreshed log command examples and coverage tests.