### PR TITLE
fix(log): align ddns and notice columns with api responses

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -307,7 +307,10 @@ ikuai-cli log system list --human-time
 ikuai-cli log arp list
 ikuai-cli log auth list
 ikuai-cli log dhcp list
+ikuai-cli log pppoe list
 ikuai-cli log web list
+ikuai-cli log ddns list
+ikuai-cli log notice list
 ikuai-cli log wireless list
 ikuai-cli log system delete --yes
 ```

--- a/internal/cmd/log/behavior_test.go
+++ b/internal/cmd/log/behavior_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/ikuaidev/ikuai-cli/internal/api"
@@ -90,6 +91,74 @@ func TestSystemLogClearRequestsDelete(t *testing.T) {
 	want := "{\"message\":\"cleared\"}\n"
 	if got != want {
 		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestDdnsLogListUsesResultColumn(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.Table
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-log"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			if req.URL.Path != "/api/v4.0/log/ddns" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/log/ddns")
+			}
+			return jsonResponse(`{"code":0,"message":"Success","results":{"data":[{"id":1,"timestamp":1778060866,"domain":"www.ali123.com","interface":"auto","ip_addr":"--","result":"失败","event":"错误: 认证失败"}],"total":1}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"ddns", "list", "--page", "1", "--page-size", "5"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "RESULT") || !strings.Contains(got, "失败") {
+		t.Fatalf("ddns table should show result column and value: %q", got)
+	}
+	if strings.Contains(got, "STATUS") {
+		t.Fatalf("ddns table should not show stale status column: %q", got)
+	}
+}
+
+func TestNoticeLogListUsesEventColumn(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.Table
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-log"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			if req.URL.Path != "/api/v4.0/log/notice" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/log/notice")
+			}
+			return jsonResponse(`{"code":0,"message":"Success","results":{"data":[{"id":1,"timestamp":1778064504,"type":"实时通知","ip_addr":"192.168.99.100","event":"已收到通知"}],"total":1}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"notice", "list", "--page", "1", "--page-size", "5"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "EVENT") || !strings.Contains(got, "已收到通知") {
+		t.Fatalf("notice table should show event column and value: %q", got)
+	}
+	if strings.Contains(got, "TITLE") || strings.Contains(got, "CONTENT") {
+		t.Fatalf("notice table should not show stale title/content columns: %q", got)
 	}
 }
 

--- a/internal/cmd/log/command.go
+++ b/internal/cmd/log/command.go
@@ -18,8 +18,8 @@ var logResources = []logResource{
 	{name: "pppoe", apiPath: "log/pppoe", defaultColumns: []string{"id", "timestamp", "interface", "content"}},
 	{name: "system", apiPath: "log/system", defaultColumns: []string{"id", "timestamp", "content"}},
 	{name: "web", apiPath: "log/web_activity", defaultColumns: []string{"id", "timestamp", "username", "ip_addr", "function", "event"}},
-	{name: "ddns", apiPath: "log/ddns", defaultColumns: []string{"id", "timestamp", "domain", "status", "ip_addr", "message"}},
-	{name: "notice", apiPath: "log/notice", defaultColumns: []string{"id", "timestamp", "type", "title", "content"}},
+	{name: "ddns", apiPath: "log/ddns", defaultColumns: []string{"id", "timestamp", "domain", "result", "ip_addr", "event"}},
+	{name: "notice", apiPath: "log/notice", defaultColumns: []string{"id", "timestamp", "type", "event", "ip_addr"}},
 	{name: "wireless", apiPath: "log/wireless", defaultColumns: []string{"id", "timestamp", "action", "mac", "apmac", "ssid", "errmsg", "signal"}},
 }
 


### PR DESCRIPTION
## Summary

- Aligns DDNS and notice log table columns with real router output.
- Adds regression tests for the updated default columns.
- Updates the CLI reference with missing log examples.