### PR TITLE
fix(auth-server): align config output and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ ikuai-cli ships with a [`SKILL.md`](./SKILL.md) and domain-specific [skills](./s
 | [vpn](skills/vpn.md) | PPTP, L2TP, OpenVPN, IKEv2, IPSec, WireGuard |
 | [objects](skills/objects.md) | IP, IPv6, MAC, port, protocol, domain, time object groups |
 | [system](skills/system.md) | Config, schedules, remote access, VRRP, backup, upgrade, web admin |
+| [auth-server](skills/auth-server.md) | Web authentication service config |
 | [batch](skills/batch.md) | Multi-command workflows: init, bulk DHCP, backup |
 
 ### Install Skills

--- a/README_CN.md
+++ b/README_CN.md
@@ -161,6 +161,7 @@ ikuai-cli 内置 [`SKILL.md`](./SKILL.md) 和领域 [skills](./skills/)，让 AI
 | [vpn](skills/vpn.md) | PPTP、L2TP、OpenVPN、IKEv2、IPSec、WireGuard |
 | [objects](skills/objects.md) | IP、IPv6、MAC、端口、协议、域名、时间对象组 |
 | [system](skills/system.md) | 系统配置、定时任务、远程访问、VRRP、备份、升级、Web 管理账号 |
+| [auth-server](skills/auth-server.md) | Web 认证服务配置 |
 | [batch](skills/batch.md) | 组合工作流：初始化、批量 DHCP、配置备份 |
 
 ### 安装 Skills

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -357,7 +357,7 @@ ikuai-cli advanced snmpd set --enabled yes --listen-port 161 --version 2 --commu
 
 ```bash
 ikuai-cli auth-server get
-ikuai-cli auth-server set --data '{"enabled":true}'
+ikuai-cli auth-server set --idle-time 60 --max-time 0
 ```
 
 ## Objects

--- a/internal/cmd/authserver/behavior_test.go
+++ b/internal/cmd/authserver/behavior_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/ikuaidev/ikuai-cli/internal/api"
@@ -44,6 +45,37 @@ func TestGetRequestsExpectedEndpoint(t *testing.T) {
 	}
 }
 
+func TestGetUsesDefaultColumns(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.Table
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-authsrv"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			return jsonResponse(`{"code":0,"message":"Success","results":{"data":[{"id":1,"enabled":"no","interface":"lan1","idle_time":60,"max_time":0,"user_auth":1,"coupon_auth":0,"phone_auth":0,"static_pwd":1,"nopasswd":0,"https_redirect":0,"group_key":"secret"}]}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"get"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "ENABLED") || !strings.Contains(got, "lan1") {
+		t.Fatalf("auth-server get table should show default columns: %q", got)
+	}
+	if strings.Contains(got, "GROUP_KEY") || strings.Contains(got, "secret") {
+		t.Fatalf("auth-server get table should not show non-default sensitive columns: %q", got)
+	}
+}
+
 func TestSetSendsExpectedJSONBody(t *testing.T) {
 	t.Parallel()
 
@@ -51,21 +83,27 @@ func TestSetSendsExpectedJSONBody(t *testing.T) {
 	app := cliapp.New(&out, &out)
 	app.Format = output.JSON
 	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-authsrv"}
+	seenGet := false
 	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			if req.Method != http.MethodPut {
-				t.Fatalf("method = %q, want %q", req.Method, http.MethodPut)
-			}
 			if req.URL.String() != "https://router.local/api/v4.0/auth/web/services" {
 				t.Fatalf("URL = %q, want %q", req.URL.String(), "https://router.local/api/v4.0/auth/web/services")
+			}
+			if req.Method == http.MethodGet {
+				seenGet = true
+				return jsonResponse(`{"code":0,"message":"Success","results":{"data":[{"id":1,"enabled":"no","max_time":0,"idle_time":60,"user_auth":1,"interface":"lan1"}]}}`), nil
+			}
+			if req.Method != http.MethodPut {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodPut)
 			}
 
 			body, err := io.ReadAll(req.Body)
 			if err != nil {
 				t.Fatalf("ReadAll() error = %v", err)
 			}
-			if string(body) != `{"enable":"yes"}` {
-				t.Fatalf("body = %q, want %q", string(body), `{"enable":"yes"}`)
+			want := `{"enabled":"yes","id":1,"idle_time":120,"interface":"lan1","max_time":0,"user_auth":1}`
+			if string(body) != want {
+				t.Fatalf("body = %q, want %q", string(body), want)
 			}
 
 			return jsonResponse(`{"code":0,"message":"saved","data":null}`), nil
@@ -73,9 +111,12 @@ func TestSetSendsExpectedJSONBody(t *testing.T) {
 	})
 
 	cmd := New(app)
-	cmd.SetArgs([]string{"set", "--data", `{"enable":"yes"}`})
+	cmd.SetArgs([]string{"set", "--enabled", "yes", "--idle-time", "120"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
+	}
+	if !seenGet {
+		t.Fatal("set should read current config before PUT")
 	}
 
 	got := out.String()

--- a/internal/cmd/authserver/command.go
+++ b/internal/cmd/authserver/command.go
@@ -1,9 +1,18 @@
 package authserver
 
 import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
 	"github.com/ikuaidev/ikuai-cli/internal/cliapp"
 	"github.com/spf13/cobra"
 )
+
+var authServerDefaultColumns = []string{
+	"id", "enabled", "interface", "idle_time", "max_time", "user_auth",
+	"coupon_auth", "phone_auth", "static_pwd", "nopasswd", "https_redirect",
+}
 
 var authServerFieldMap = map[string]string{
 	"enabled":         "enabled",
@@ -26,6 +35,18 @@ var authServerFieldMap = map[string]string{
 	"https-redirect":  "https_redirect",
 }
 
+var authServerIntegerFields = map[string]bool{
+	"max_time":       true,
+	"idle_time":      true,
+	"user_auth":      true,
+	"coupon_auth":    true,
+	"phone_auth":     true,
+	"static_pwd":     true,
+	"nopasswd":       true,
+	"weixin":         true,
+	"https_redirect": true,
+}
+
 func New(app *cliapp.Runtime) *cobra.Command {
 	authServerCmd := &cobra.Command{
 		Use:   "auth-server",
@@ -39,6 +60,7 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			if err := app.RequireAuth(); err != nil {
 				return err
 			}
+			app.DefaultColumns = authServerDefaultColumns
 			raw, err := app.APIClient.Get(cliapp.APIBase+"/auth/web/services", nil)
 			if err != nil {
 				return err
@@ -56,7 +78,14 @@ func New(app *cliapp.Runtime) *cobra.Command {
 				return err
 			}
 			data, _ := cmd.Flags().GetString("data")
-			body, err := cliapp.MergeDataWithFlags(data, cmd, authServerFieldMap)
+			changes, err := mergeAuthServerChanges(data, cmd)
+			if err != nil {
+				return err
+			}
+			if len(changes) == 0 {
+				return &cliapp.ValidationError{Message: "at least one config field is required"}
+			}
+			body, err := buildAuthServerSetBody(app, changes)
 			if err != nil {
 				return err
 			}
@@ -90,4 +119,79 @@ func New(app *cliapp.Runtime) *cobra.Command {
 
 	authServerCmd.AddCommand(authServerGetCmd, authServerSetCmd)
 	return authServerCmd
+}
+
+func mergeAuthServerChanges(data string, cmd *cobra.Command) (map[string]interface{}, error) {
+	changes, err := cliapp.MergeDataWithFlags(data, cmd, authServerFieldMap)
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range changes {
+		if !authServerIntegerFields[key] {
+			continue
+		}
+		switch typed := value.(type) {
+		case string:
+			if typed == "" {
+				continue
+			}
+			n, err := strconv.ParseInt(typed, 10, 64)
+			if err != nil {
+				return nil, &cliapp.ValidationError{Message: fmt.Sprintf("invalid integer for %s: %s", key, typed)}
+			}
+			changes[key] = n
+		}
+	}
+	return changes, nil
+}
+
+func buildAuthServerSetBody(app *cliapp.Runtime, changes map[string]interface{}) (map[string]interface{}, error) {
+	readClient := app.APIClient
+	if app.APIClient.DryRun {
+		readClient = app.NewClient(app.Session.BaseURL, app.Session.Token)
+	}
+	raw, err := readClient.Get(cliapp.APIBase+"/auth/web/services", nil)
+	if err != nil {
+		return nil, err
+	}
+	current, err := extractAuthServerConfig(raw)
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range changes {
+		current[key] = value
+	}
+	return current, nil
+}
+
+func extractAuthServerConfig(raw json.RawMessage) (map[string]interface{}, error) {
+	var value interface{}
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, err
+	}
+	if obj, ok := findAuthServerConfigObject(value); ok {
+		return obj, nil
+	}
+	return nil, &cliapp.ValidationError{Message: "empty auth-server config response"}
+}
+
+func findAuthServerConfigObject(value interface{}) (map[string]interface{}, bool) {
+	switch typed := value.(type) {
+	case []interface{}:
+		if len(typed) == 0 {
+			return nil, false
+		}
+		return findAuthServerConfigObject(typed[0])
+	case map[string]interface{}:
+		for _, key := range []string{"data", "results"} {
+			if inner, ok := typed[key]; ok {
+				if obj, found := findAuthServerConfigObject(inner); found {
+					return obj, true
+				}
+			}
+		}
+		return typed, true
+	default:
+		return nil, false
+	}
 }

--- a/internal/cmd/authserver/command.go
+++ b/internal/cmd/authserver/command.go
@@ -130,8 +130,7 @@ func mergeAuthServerChanges(data string, cmd *cobra.Command) (map[string]interfa
 		if !authServerIntegerFields[key] {
 			continue
 		}
-		switch typed := value.(type) {
-		case string:
+		if typed, ok := value.(string); ok {
 			if typed == "" {
 				continue
 			}

--- a/skills/auth-server.md
+++ b/skills/auth-server.md
@@ -6,12 +6,10 @@ description: iKuai web auth server — get/set portal authentication config.
 # Auth Server
 
 ```bash
-ikuai-cli auth-server get
-ikuai-cli auth-server get --columns enabled,interface,idle_time,max_time
-ikuai-cli auth-server set --data '{"enabled":"no","max_time":0,"idle_time":60,...}' --user-auth 1
+ikuai-cli auth-server get --format json
+ikuai-cli auth-server get --columns enabled,interface,idle_time,max_time --format json
+ikuai-cli auth-server set --idle-time 60 --max-time 0 --format json
 ```
-
-全量更新（141 字段），建议 get → 修改 JSON → set。支持 flags 覆盖 `--data` 中的值。
 
 常用 flags：`--enabled`, `--max-time`, `--idle-time`, `--user-auth`, `--coupon-auth`, `--phone-auth`,
 `--static-pwd`, `--nopasswd`, `--weixin`, `--interface`, `--passwd`, `--whitelist`, `--whitelist-https`,


### PR DESCRIPTION
## Summary

- Improves `auth-server get` table output so it shows compact, useful columns by default.
- Makes `auth-server set` safely preserve existing configuration while changing selected fields.
- Updates auth-server examples in README, CLI reference, and skill docs.
- Adds behavior coverage for auth-server output and update handling.