### PR TITLE
fix(network): add list actions for interface inventory

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -105,8 +105,10 @@ ikuai-cli network dns get
 ikuai-cli network dns set --dns1 114.114.114.114 --dns2 8.8.8.8
 
 # WAN / LAN
-ikuai-cli network wan
-ikuai-cli network lan
+ikuai-cli network wan list
+ikuai-cli network wan-vlan list
+ikuai-cli network lan list
+ikuai-cli network physical list
 
 # DHCP
 ikuai-cli network dhcp list --page 1 --page-size 50

--- a/internal/cmd/network/behavior_test.go
+++ b/internal/cmd/network/behavior_test.go
@@ -64,6 +64,41 @@ func TestNatListBuildsExpectedQueryParams(t *testing.T) {
 	}
 }
 
+func TestWANListUsesConfigEndpointWithoutPagination(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-wan"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			if req.URL.Path != "/api/v4.0/interfaces/wan-config" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/interfaces/wan-config")
+			}
+			if req.URL.RawQuery != "" {
+				t.Fatalf("query = %q, want empty", req.URL.RawQuery)
+			}
+			return jsonResponse(`{"code":0,"data":[{"id":1,"tagname":"wan1","internet":3,"mtu":1480}],"total":1}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"wan", "list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := out.String()
+	want := `[{"id":1,"internet":3,"mtu":1480,"tagname":"wan1"}]` + "\n"
+	if got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
 func TestDHCPCreateMissingRequiredFlags(t *testing.T) {
 	t.Parallel()
 	var out bytes.Buffer

--- a/internal/cmd/network/command.go
+++ b/internal/cmd/network/command.go
@@ -25,6 +25,21 @@ var natFlagDescs = map[string]string{
 	"dst-port":      "Destination port (comma-separated)",
 }
 
+func readOnlyNetworkRunE(app *cliapp.Runtime, apiPath string, defaultColumns []string) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := app.RequireAuth(); err != nil {
+			return err
+		}
+		app.DefaultColumns = defaultColumns
+		raw, err := app.APIClient.Get(cliapp.APIBase+apiPath, nil)
+		if err != nil {
+			return err
+		}
+		app.PrintRaw(raw)
+		return nil
+	}
+}
+
 func New(app *cliapp.Runtime) *cobra.Command {
 	networkCmd := &cobra.Command{
 		Use:   "network",
@@ -36,73 +51,21 @@ func New(app *cliapp.Runtime) *cobra.Command {
   ikuai-cli network nat list`,
 	}
 
-	networkWANCmd := &cobra.Command{
-		Use:   "wan",
-		Short: "WAN interface config",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := app.RequireAuth(); err != nil {
-				return err
-			}
-			app.DefaultColumns = []string{"id", "tagname", "internet", "ip_mask", "gateway", "mac", "mtu", "speed", "enabled"}
-			raw, err := app.APIClient.Get(cliapp.APIBase+"/interfaces/wan-config", nil)
-			if err != nil {
-				return err
-			}
-			app.PrintRaw(raw)
-			return nil
-		},
-	}
+	wanRunE := readOnlyNetworkRunE(app, "/interfaces/wan-config", []string{"id", "tagname", "internet", "ip_mask", "gateway", "mac", "mtu", "speed"})
+	networkWANCmd := &cobra.Command{Use: "wan", Short: "WAN interface config", Args: cobra.NoArgs, RunE: wanRunE}
+	networkWANListCmd := &cobra.Command{Use: "list", Short: "List WAN interface configs", Args: cobra.NoArgs, RunE: wanRunE}
 
-	networkWANVLANCmd := &cobra.Command{
-		Use:   "wan-vlan",
-		Short: "WAN VLAN config",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := app.RequireAuth(); err != nil {
-				return err
-			}
-			app.DefaultColumns = []string{"id", "tagname", "interface", "vlan_id", "ip_addr", "netmask", "gateway", "enabled"}
-			raw, err := app.APIClient.Get(cliapp.APIBase+"/interfaces/wan-vlan-config", nil)
-			if err != nil {
-				return err
-			}
-			app.PrintRaw(raw)
-			return nil
-		},
-	}
+	wanVLANRunE := readOnlyNetworkRunE(app, "/interfaces/wan-vlan-config", []string{"id", "vlan_name", "interface", "vlan_id", "ip_mask", "gateway", "enabled"})
+	networkWANVLANCmd := &cobra.Command{Use: "wan-vlan", Short: "WAN VLAN config", Args: cobra.NoArgs, RunE: wanVLANRunE}
+	networkWANVLANListCmd := &cobra.Command{Use: "list", Short: "List WAN VLAN configs", Args: cobra.NoArgs, RunE: wanVLANRunE}
 
-	networkLANCmd := &cobra.Command{
-		Use:   "lan",
-		Short: "LAN interface config",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := app.RequireAuth(); err != nil {
-				return err
-			}
-			app.DefaultColumns = []string{"id", "tagname", "ip_mask", "bandeth", "dhcp_server", "vlan"}
-			raw, err := app.APIClient.Get(cliapp.APIBase+"/interfaces/lan-config", nil)
-			if err != nil {
-				return err
-			}
-			app.PrintRaw(raw)
-			return nil
-		},
-	}
+	lanRunE := readOnlyNetworkRunE(app, "/interfaces/lan-config", []string{"id", "tagname", "ip_mask", "bandeth", "dhcp_server", "vlan"})
+	networkLANCmd := &cobra.Command{Use: "lan", Short: "LAN interface config", Args: cobra.NoArgs, RunE: lanRunE}
+	networkLANListCmd := &cobra.Command{Use: "list", Short: "List LAN interface configs", Args: cobra.NoArgs, RunE: lanRunE}
 
-	networkPhysicalCmd := &cobra.Command{
-		Use:   "physical",
-		Short: "Physical NIC info",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := app.RequireAuth(); err != nil {
-				return err
-			}
-			app.DefaultColumns = []string{"name", "interface", "link", "speed", "duplex", "mac", "type", "driver"}
-			raw, err := app.APIClient.Get(cliapp.APIBase+"/interfaces/physical", nil)
-			if err != nil {
-				return err
-			}
-			app.PrintRaw(raw)
-			return nil
-		},
-	}
+	physicalRunE := readOnlyNetworkRunE(app, "/interfaces/physical", []string{"name", "interface", "link", "speed", "duplex", "mac", "type", "driver"})
+	networkPhysicalCmd := &cobra.Command{Use: "physical", Short: "Physical NIC info", Args: cobra.NoArgs, RunE: physicalRunE}
+	networkPhysicalListCmd := &cobra.Command{Use: "list", Short: "List physical NIC info", Args: cobra.NoArgs, RunE: physicalRunE}
 
 	networkDNSCmd := &cobra.Command{Use: "dns", Short: "DNS config"}
 
@@ -1042,6 +1005,10 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		},
 	}
 
+	networkWANCmd.AddCommand(networkWANListCmd)
+	networkWANVLANCmd.AddCommand(networkWANVLANListCmd)
+	networkLANCmd.AddCommand(networkLANListCmd)
+	networkPhysicalCmd.AddCommand(networkPhysicalListCmd)
 	networkCmd.AddCommand(networkWANCmd, networkWANVLANCmd, networkLANCmd, networkPhysicalCmd)
 
 	networkCmd.AddCommand(networkDNSCmd)

--- a/internal/cmd/network/command_test.go
+++ b/internal/cmd/network/command_test.go
@@ -17,7 +17,12 @@ func TestNewRegistersExpectedNetworkCommands(t *testing.T) {
 		args     []string
 		wantUse  string
 		wantFlag string
+		noFlag   string
 	}{
+		{name: "wan list no pagination", args: []string{"wan", "list"}, wantUse: "list", noFlag: "page"},
+		{name: "wan-vlan list no pagination", args: []string{"wan-vlan", "list"}, wantUse: "list", noFlag: "page"},
+		{name: "lan list no pagination", args: []string{"lan", "list"}, wantUse: "list", noFlag: "page-size"},
+		{name: "physical list no pagination", args: []string{"physical", "list"}, wantUse: "list", noFlag: "page"},
 		{name: "dns set data flag", args: []string{"dns", "set"}, wantUse: "set", wantFlag: "data"},
 		{name: "dns proxy list pagination", args: []string{"dns", "proxy", "list"}, wantUse: "list", wantFlag: "page-size"},
 		{name: "dhcp list pagination", args: []string{"dhcp", "list"}, wantUse: "list", wantFlag: "page"},
@@ -40,8 +45,11 @@ func TestNewRegistersExpectedNetworkCommands(t *testing.T) {
 			if found.Name() != tt.wantUse {
 				t.Fatalf("Find(%v) command = %q, want %q", tt.args, found.Name(), tt.wantUse)
 			}
-			if found.Flags().Lookup(tt.wantFlag) == nil {
+			if tt.wantFlag != "" && found.Flags().Lookup(tt.wantFlag) == nil {
 				t.Fatalf("Find(%v) missing flag %q", tt.args, tt.wantFlag)
+			}
+			if tt.noFlag != "" && found.Flags().Lookup(tt.noFlag) != nil {
+				t.Fatalf("Find(%v) unexpectedly has flag %q", tt.args, tt.noFlag)
 			}
 		})
 	}

--- a/skills/network.md
+++ b/skills/network.md
@@ -61,10 +61,10 @@ ikuai-cli network dhcp6 access-rule delete <ID> --yes --format json
 ## WAN / LAN / 接口
 
 ```bash
-ikuai-cli network wan --format json
-ikuai-cli network wan-vlan --format json
-ikuai-cli network lan --format json
-ikuai-cli network physical --format json
+ikuai-cli network wan list --format json
+ikuai-cli network wan-vlan list --format json
+ikuai-cli network lan list --format json
+ikuai-cli network physical list --format json
 ```
 
 ## VLAN


### PR DESCRIPTION
## Summary

- Add standard `network wan list`, `network wan-vlan list`, `network lan list`, and `network physical list` commands for interface inventory.
- Keep the existing bare inventory commands working for compatibility.
- Update network command docs and Agent examples to use the new list command shape.