### PR TITLE
fix(users): complete auth-server and online session command alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ CLAUDE.md
 AGENTS.md
 .claude/
 document/
+/web-api-yaml/
 
 # Build artifacts
 dist/

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ ikuai-cli network dns get                    # DNS config
 ikuai-cli network dns proxy create --domain example.com --dns-addr 8.8.8.8 --parse-type ipv4
 ikuai-cli network pppoe set --comment maintenance --mtu 1480 --mru 1480
 ikuai-cli users online                       # Online users
+ikuai-cli users online get 1                 # Online user detail
 ikuai-cli security acl list                  # Security rules
 ikuai-cli log system list --human-time       # System logs
 ```
@@ -170,7 +171,7 @@ ikuai-cli ships with a [`SKILL.md`](./SKILL.md) and domain-specific [skills](./s
 **[Skills CLI](https://github.com/vercel-labs/skills) (Recommended):**
 
 ```bash
-npx skills add ikuai/ikuai-cli
+npx skills add ikuaidev/ikuai-cli
 ```
 
 | Flag | Description |

--- a/README_CN.md
+++ b/README_CN.md
@@ -96,6 +96,7 @@ ikuai-cli network dns get                    # DNS 配置
 ikuai-cli network dns proxy create --domain example.com --dns-addr 8.8.8.8 --parse-type ipv4
 ikuai-cli network pppoe set --comment maintenance --mtu 1480 --mru 1480
 ikuai-cli users online                       # 在线用户
+ikuai-cli users online get 1                 # 在线用户详情
 ikuai-cli security acl list                  # 安全策略
 ikuai-cli log system list --human-time       # 系统日志
 ```
@@ -170,7 +171,7 @@ ikuai-cli 内置 [`SKILL.md`](./SKILL.md) 和领域 [skills](./skills/)，让 AI
 **[Skills CLI](https://github.com/vercel-labs/skills)（推荐）：**
 
 ```bash
-npx skills add ikuai/ikuai-cli
+npx skills add ikuaidev/ikuai-cli
 ```
 
 | 参数 | 说明 |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -135,6 +135,7 @@ ikuai-cli users accounts create --username "guest" --password "guest123"
 ikuai-cli users accounts update 1 --comment "updated"
 ikuai-cli users accounts delete 1 --yes
 ikuai-cli users online
+ikuai-cli users online get 1
 ikuai-cli users kick 1 --yes
 ikuai-cli users packages list
 ikuai-cli users packages create --name "month-card" --time "1m" --price 100 --up-speed 500 --down-speed 1000
@@ -374,7 +375,6 @@ ikuai-cli advanced snmpd set --enabled yes --listen-port 161 --version 2 --commu
 
 ```bash
 ikuai-cli auth-server get
-ikuai-cli auth-server set --idle-time 60 --max-time 0
 ```
 
 ## Objects

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -59,7 +59,7 @@ Reference implementation:
 | `vpn` | covered | OpenVPN client listing and WireGuard peer creation covered |
 | `wireless` | covered | blacklist listing and AC service update covered |
 | `advanced` | covered | advanced-service user listing and SNMPD update covered |
-| `auth-server` | covered | auth web service get/set covered |
+| `auth-server` | covered | auth web service get covered |
 | `log` | covered | log listing and clear behavior covered |
 
 These tests validate request method, path, query parameters, JSON body shape, and output behavior at the CLI layer.

--- a/internal/cmd/authserver/behavior_test.go
+++ b/internal/cmd/authserver/behavior_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/ikuaidev/ikuai-cli/internal/cliapp"
 	"github.com/ikuaidev/ikuai-cli/internal/output"
 	"github.com/ikuaidev/ikuai-cli/internal/session"
+	"github.com/spf13/cobra"
 )
 
 func TestGetRequestsExpectedEndpoint(t *testing.T) {
@@ -76,53 +79,67 @@ func TestGetUsesDefaultColumns(t *testing.T) {
 	}
 }
 
-func TestSetSendsExpectedJSONBody(t *testing.T) {
+func TestAuthServerDoesNotExposeSetWithoutYAMLPut(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
 	app := cliapp.New(&out, &out)
-	app.Format = output.JSON
-	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-authsrv"}
-	seenGet := false
-	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
-		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			if req.URL.String() != "https://router.local/api/v4.0/auth/web/services" {
-				t.Fatalf("URL = %q, want %q", req.URL.String(), "https://router.local/api/v4.0/auth/web/services")
-			}
-			if req.Method == http.MethodGet {
-				seenGet = true
-				return jsonResponse(`{"code":0,"message":"Success","results":{"data":[{"id":1,"enabled":"no","max_time":0,"idle_time":60,"user_auth":1,"interface":"lan1"}]}}`), nil
-			}
-			if req.Method != http.MethodPut {
-				t.Fatalf("method = %q, want %q", req.Method, http.MethodPut)
-			}
-
-			body, err := io.ReadAll(req.Body)
-			if err != nil {
-				t.Fatalf("ReadAll() error = %v", err)
-			}
-			want := `{"enabled":"yes","id":1,"idle_time":120,"interface":"lan1","max_time":0,"user_auth":1}`
-			if string(body) != want {
-				t.Fatalf("body = %q, want %q", string(body), want)
-			}
-
-			return jsonResponse(`{"code":0,"message":"saved","data":null}`), nil
-		}),
-	})
-
 	cmd := New(app)
-	cmd.SetArgs([]string{"set", "--enabled", "yes", "--idle-time", "120"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
-	}
-	if !seenGet {
-		t.Fatal("set should read current config before PUT")
+	if findSubcommand(cmd, "set") != nil {
+		t.Fatal("auth-server set must not be exposed while YAML lacks PUT /api/v4.0/auth/web/services")
 	}
 
-	got := out.String()
-	want := "{\"message\":\"saved\"}\n"
-	if got != want {
-		t.Fatalf("output = %q, want %q", got, want)
+	root, err := findRepoRoot()
+	if err != nil {
+		t.Skipf("repo root not found: %v", err)
+	}
+	yamlPath := filepath.Join(root, "web-api-yaml", "yaml", "auth", "auth-web-services.yaml")
+	yamlBody, err := os.ReadFile(yamlPath) // #nosec G304 -- test reads a fixed repository fixture path.
+	if err != nil {
+		t.Skipf("YAML contract not available at %s: %v", yamlPath, err)
+	}
+	if authServerYAMLDeclaresPut(string(yamlBody)) {
+		t.Fatal("YAML now declares PUT /api/v4.0/auth/web/services; update CLI and this guard test intentionally")
+	}
+}
+
+func authServerYAMLDeclaresPut(body string) bool {
+	inPath := false
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "  /api/v4.0/") {
+			inPath = strings.TrimSuffix(strings.TrimSpace(line), ":") == "/api/v4.0/auth/web/services"
+			continue
+		}
+		if inPath && strings.TrimSpace(line) == "put:" {
+			return true
+		}
+	}
+	return false
+}
+
+func findSubcommand(cmd *cobra.Command, name string) *cobra.Command {
+	for _, child := range cmd.Commands() {
+		if child.Name() == name {
+			return child
+		}
+	}
+	return nil
+}
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parent
 	}
 }
 

--- a/internal/cmd/authserver/command.go
+++ b/internal/cmd/authserver/command.go
@@ -1,10 +1,6 @@
 package authserver
 
 import (
-	"encoding/json"
-	"fmt"
-	"strconv"
-
 	"github.com/ikuaidev/ikuai-cli/internal/cliapp"
 	"github.com/spf13/cobra"
 )
@@ -12,39 +8,6 @@ import (
 var authServerDefaultColumns = []string{
 	"id", "enabled", "interface", "idle_time", "max_time", "user_auth",
 	"coupon_auth", "phone_auth", "static_pwd", "nopasswd", "https_redirect",
-}
-
-var authServerFieldMap = map[string]string{
-	"enabled":         "enabled",
-	"max-time":        "max_time",
-	"idle-time":       "idle_time",
-	"user-auth":       "user_auth",
-	"coupon-auth":     "coupon_auth",
-	"phone-auth":      "phone_auth",
-	"static-pwd":      "static_pwd",
-	"nopasswd":        "nopasswd",
-	"weixin":          "weixin",
-	"interface":       "interface",
-	"passwd":          "passwd",
-	"whitelist":       "whitelist",
-	"whitelist-https": "whitelist_https",
-	"whiteip":         "whiteip",
-	"noauth-mac":      "noauth_mac",
-	"radius-ip":       "radius_ip",
-	"radius-key":      "radius_key",
-	"https-redirect":  "https_redirect",
-}
-
-var authServerIntegerFields = map[string]bool{
-	"max_time":       true,
-	"idle_time":      true,
-	"user_auth":      true,
-	"coupon_auth":    true,
-	"phone_auth":     true,
-	"static_pwd":     true,
-	"nopasswd":       true,
-	"weixin":         true,
-	"https_redirect": true,
 }
 
 func New(app *cliapp.Runtime) *cobra.Command {
@@ -70,127 +33,6 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		},
 	}
 
-	authServerSetCmd := &cobra.Command{
-		Use:   "set",
-		Short: "Update web auth config",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := app.RequireAuth(); err != nil {
-				return err
-			}
-			data, _ := cmd.Flags().GetString("data")
-			changes, err := mergeAuthServerChanges(data, cmd)
-			if err != nil {
-				return err
-			}
-			if len(changes) == 0 {
-				return &cliapp.ValidationError{Message: "at least one config field is required"}
-			}
-			body, err := buildAuthServerSetBody(app, changes)
-			if err != nil {
-				return err
-			}
-			raw, err := app.APIClient.Put(cliapp.APIBase+"/auth/web/services", body)
-			if err != nil {
-				return err
-			}
-			app.PrintRaw(raw)
-			return nil
-		},
-	}
-	authServerSetCmd.Flags().String("data", "{}", "JSON body")
-	authServerSetCmd.Flags().String("enabled", "", "Service enabled (yes/no)")
-	authServerSetCmd.Flags().String("max-time", "", "Re-auth timeout (minutes, 0=unlimited)")
-	authServerSetCmd.Flags().String("idle-time", "", "Idle timeout (seconds, 0=unlimited)")
-	authServerSetCmd.Flags().String("user-auth", "", "User/password auth (0/1)")
-	authServerSetCmd.Flags().String("coupon-auth", "", "Coupon auth (0/1)")
-	authServerSetCmd.Flags().String("phone-auth", "", "Phone auth (0/1)")
-	authServerSetCmd.Flags().String("static-pwd", "", "Static password auth (0/1)")
-	authServerSetCmd.Flags().String("nopasswd", "", "One-click auth (0/1)")
-	authServerSetCmd.Flags().String("weixin", "", "WeChat auth (0/1)")
-	authServerSetCmd.Flags().String("interface", "", "Auth interface")
-	authServerSetCmd.Flags().String("passwd", "", "Static password (MD5)")
-	authServerSetCmd.Flags().String("whitelist", "", "HTTP whitelist domains (comma-separated)")
-	authServerSetCmd.Flags().String("whitelist-https", "", "HTTPS whitelist domains (comma-separated)")
-	authServerSetCmd.Flags().String("whiteip", "", "Whitelist IPs (comma-separated)")
-	authServerSetCmd.Flags().String("noauth-mac", "", "No-auth MAC addresses (comma-separated)")
-	authServerSetCmd.Flags().String("radius-ip", "", "RADIUS server IP")
-	authServerSetCmd.Flags().String("radius-key", "", "RADIUS shared secret")
-	authServerSetCmd.Flags().String("https-redirect", "", "HTTPS redirect to portal (0/1)")
-
-	authServerCmd.AddCommand(authServerGetCmd, authServerSetCmd)
+	authServerCmd.AddCommand(authServerGetCmd)
 	return authServerCmd
-}
-
-func mergeAuthServerChanges(data string, cmd *cobra.Command) (map[string]interface{}, error) {
-	changes, err := cliapp.MergeDataWithFlags(data, cmd, authServerFieldMap)
-	if err != nil {
-		return nil, err
-	}
-	for key, value := range changes {
-		if !authServerIntegerFields[key] {
-			continue
-		}
-		if typed, ok := value.(string); ok {
-			if typed == "" {
-				continue
-			}
-			n, err := strconv.ParseInt(typed, 10, 64)
-			if err != nil {
-				return nil, &cliapp.ValidationError{Message: fmt.Sprintf("invalid integer for %s: %s", key, typed)}
-			}
-			changes[key] = n
-		}
-	}
-	return changes, nil
-}
-
-func buildAuthServerSetBody(app *cliapp.Runtime, changes map[string]interface{}) (map[string]interface{}, error) {
-	readClient := app.APIClient
-	if app.APIClient.DryRun {
-		readClient = app.NewClient(app.Session.BaseURL, app.Session.Token)
-	}
-	raw, err := readClient.Get(cliapp.APIBase+"/auth/web/services", nil)
-	if err != nil {
-		return nil, err
-	}
-	current, err := extractAuthServerConfig(raw)
-	if err != nil {
-		return nil, err
-	}
-	for key, value := range changes {
-		current[key] = value
-	}
-	return current, nil
-}
-
-func extractAuthServerConfig(raw json.RawMessage) (map[string]interface{}, error) {
-	var value interface{}
-	if err := json.Unmarshal(raw, &value); err != nil {
-		return nil, err
-	}
-	if obj, ok := findAuthServerConfigObject(value); ok {
-		return obj, nil
-	}
-	return nil, &cliapp.ValidationError{Message: "empty auth-server config response"}
-}
-
-func findAuthServerConfigObject(value interface{}) (map[string]interface{}, bool) {
-	switch typed := value.(type) {
-	case []interface{}:
-		if len(typed) == 0 {
-			return nil, false
-		}
-		return findAuthServerConfigObject(typed[0])
-	case map[string]interface{}:
-		for _, key := range []string{"data", "results"} {
-			if inner, ok := typed[key]; ok {
-				if obj, found := findAuthServerConfigObject(inner); found {
-					return obj, true
-				}
-			}
-		}
-		return typed, true
-	default:
-		return nil, false
-	}
 }

--- a/internal/cmd/repl.go
+++ b/internal/cmd/repl.go
@@ -29,7 +29,7 @@ var helpGroups = []struct{ name, desc string }{
 	{"users", "User management (accounts, online, kick, packages)"},
 	{"log", "System logs (arp, auth, dhcp, system, web, wireless ...)"},
 	{"system", "System config (get, schedules, remote-access, vrrp, backup, upgrade, web-admin)"},
-	{"auth-server", "Web auth server (get, set)"},
+	{"auth-server", "Web auth server (get)"},
 	{"wireless", "Wireless control (blacklist, vlan, ac)"},
 	{"advanced", "Advanced services (ftp, http, samba, snmpd)"},
 	{"completion", "Generate shell completion scripts"},

--- a/internal/cmd/system/command.go
+++ b/internal/cmd/system/command.go
@@ -468,7 +468,7 @@ func systemWebAdminCmd(app *cliapp.Runtime) *cobra.Command {
 	accounts.AddCommand(webAdminCRUD(app, "account", "/system/web-admin/accounts", webAdminAccountMap, webAdminAccountFields,
 		[]string{"id", "username", "enabled", "group_id", "force", "interval", "sesstimeout", "comment"}, []string{"username", "passwd-md5", "group-id"}, addWebAdminAccountFlags)...)
 
-	passwordStatus := readCommand(app, "password-status", "Get password status", "/system/web-admin/accounts/password-status",
+	passwordStatus := readCommand(app, "password-status", "Get password status", "/system/web-admin/password-status",
 		[]string{"mod_passwd"}, func(cmd *cobra.Command) map[string]string {
 			username, _ := cmd.Flags().GetString("username")
 			return map[string]string{"username": username}

--- a/internal/cmd/users/behavior_test.go
+++ b/internal/cmd/users/behavior_test.go
@@ -108,6 +108,38 @@ func TestOnlineListBuildsExpectedQueryParams(t *testing.T) {
 	}
 }
 
+func TestOnlineGetFetchesOnlineUser(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.JSON
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-users"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			if req.URL.String() != "https://router.local/api/v4.0/auth/online-users/42" {
+				t.Fatalf("URL = %q, want %q", req.URL.String(), "https://router.local/api/v4.0/auth/online-users/42")
+			}
+			return jsonResponse(`{"code":0,"data":{"id":42,"username":"alice"}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"online", "get", "42"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := out.String()
+	want := "{\"id\":42,\"username\":\"alice\"}\n"
+	if got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
 func TestKickDeletesOnlineUser(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/users/command.go
+++ b/internal/cmd/users/command.go
@@ -137,6 +137,7 @@ func New(app *cliapp.Runtime) *cobra.Command {
 		},
 	}
 	addOnlineListFlags(onlineCmd)
+	onlineCmd.AddCommand(getByIDCmd(app, "get ID", "Get a single online session", "/auth/online-users/", onlineDefaultColumns))
 	usersCmd.AddCommand(onlineCmd)
 
 	kickCmd := &cobra.Command{

--- a/skills/auth-server.md
+++ b/skills/auth-server.md
@@ -1,6 +1,6 @@
 ---
 name: ikuai-auth-server
-description: iKuai web auth server — get/set portal authentication config.
+description: iKuai web auth server — get portal authentication config.
 ---
 
 # Auth Server
@@ -8,9 +8,4 @@ description: iKuai web auth server — get/set portal authentication config.
 ```bash
 ikuai-cli auth-server get --format json
 ikuai-cli auth-server get --columns enabled,interface,idle_time,max_time --format json
-ikuai-cli auth-server set --idle-time 60 --max-time 0 --format json
 ```
-
-常用 flags：`--enabled`, `--max-time`, `--idle-time`, `--user-auth`, `--coupon-auth`, `--phone-auth`,
-`--static-pwd`, `--nopasswd`, `--weixin`, `--interface`, `--passwd`, `--whitelist`, `--whitelist-https`,
-`--whiteip`, `--noauth-mac`, `--radius-ip`, `--radius-key`, `--https-redirect`

--- a/skills/users.md
+++ b/skills/users.md
@@ -9,6 +9,7 @@ description: iKuai user management — auth accounts CRUD, online sessions, kick
 
 ```bash
 ikuai-cli users online --format json
+ikuai-cli users online get <ID> --format json
 ikuai-cli users kick <ID> --yes --format json
 ```
 


### PR DESCRIPTION
## Summary

- Removed the unsupported `auth-server set` command from the visible command surface.
- Added `users online get ID` for reading a single online session.
- Kept `users online --page/--page-size` working against real router behavior.
- Updated README, CLI reference, compatibility docs, and command skills to match the current command set.