### PR TITLE
fix(completion): reject unsupported shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ make build
 **Shell completion:**
 
 ```bash
+mkdir -p ~/.local/share/bash-completion/completions
 ikuai-cli completion bash > ~/.local/share/bash-completion/completions/ikuai-cli
+mkdir -p ~/.zsh/completions
 ikuai-cli completion zsh  > ~/.zsh/completions/_ikuai-cli
+mkdir -p ~/.config/fish/completions
 ikuai-cli completion fish > ~/.config/fish/completions/ikuai-cli.fish
 ikuai-cli completion powershell > ikuai-cli.ps1
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -51,8 +51,11 @@ make build
 **Shell 补全：**
 
 ```bash
+mkdir -p ~/.local/share/bash-completion/completions
 ikuai-cli completion bash > ~/.local/share/bash-completion/completions/ikuai-cli
+mkdir -p ~/.zsh/completions
 ikuai-cli completion zsh  > ~/.zsh/completions/_ikuai-cli
+mkdir -p ~/.config/fish/completions
 ikuai-cli completion fish > ~/.config/fish/completions/ikuai-cli.fish
 ikuai-cli completion powershell > ikuai-cli.ps1
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -402,6 +402,7 @@ ikuai-cli objects time list --page 1 --page-size 20
 
 ```bash
 ikuai-cli version
+ikuai-cli completion --help
 ikuai-cli completion bash
 ikuai-cli completion zsh
 ikuai-cli completion fish

--- a/internal/cmd/completion/command.go
+++ b/internal/cmd/completion/command.go
@@ -18,6 +18,10 @@ Supported shells:
   zsh
   fish
   powershell`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 
 	completionCmd.AddCommand(

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -163,6 +163,22 @@ func TestCompletionPowerShellGeneratesScript(t *testing.T) {
 	}
 }
 
+func TestCompletionRejectsUnsupportedShell(t *testing.T) {
+	testRootCommand(t)
+
+	var out bytes.Buffer
+	setRootOutput(t, &out)
+
+	rootCmd.SetArgs([]string{"completion", "elvish"})
+	_, err := rootCmd.ExecuteC()
+	if err == nil {
+		t.Fatal("expected error for unsupported shell, got nil")
+	}
+	if !strings.Contains(err.Error(), `unknown command "elvish"`) {
+		t.Fatalf("error = %q, want unknown command", err.Error())
+	}
+}
+
 func TestRawAndFormatAreMutuallyExclusive(t *testing.T) {
 	testRootCommand(t)
 

--- a/skills/completion.md
+++ b/skills/completion.md
@@ -1,0 +1,21 @@
+---
+name: ikuai-completion
+description: iKuai CLI shell completion script generation for bash, zsh, fish, and PowerShell.
+---
+
+# Completion
+
+```bash
+ikuai-cli completion bash > ~/.local/share/bash-completion/completions/ikuai-cli
+ikuai-cli completion zsh > ~/.zsh/completions/_ikuai-cli
+ikuai-cli completion fish > ~/.config/fish/completions/ikuai-cli.fish
+ikuai-cli completion powershell > ikuai-cli.ps1
+```
+
+```bash
+ikuai-cli completion --help
+ikuai-cli completion bash --help
+ikuai-cli completion zsh --help
+ikuai-cli completion fish --help
+ikuai-cli completion powershell --help
+```


### PR DESCRIPTION
## Summary

- Reject unsupported completion shell names with an error instead of silently showing help.
- Add regression coverage for unsupported shell handling.
- Refresh completion installation examples and add an agent-facing completion skill.