### PR TITLE
fix: show tag-based CLI version first

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     binary: ikuai-cli
     ldflags:
       - -s -w
-      - -X github.com/ikuaidev/ikuai-cli/internal/buildinfo.Version={{ .Version }}
+      - -X github.com/ikuaidev/ikuai-cli/internal/buildinfo.Version={{ .Tag }}
       - -X github.com/ikuaidev/ikuai-cli/internal/buildinfo.Commit={{ .Commit }}
       - -X github.com/ikuaidev/ikuai-cli/internal/buildinfo.Date={{ .Date }}
     goos:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY = ikuai-cli
 CMD    = ./cmd/ikuai-cli
 DIST   = dist
-VERSION ?= dev
+VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
 DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS = -X github.com/ikuaidev/ikuai-cli/internal/buildinfo.Version=$(VERSION) -X github.com/ikuaidev/ikuai-cli/internal/buildinfo.Commit=$(COMMIT) -X github.com/ikuaidev/ikuai-cli/internal/buildinfo.Date=$(DATE)

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -63,7 +63,7 @@ func TestVersionWithFormatJSON(t *testing.T) {
 	}
 }
 
-func TestVersionDefaultsToTableOutput(t *testing.T) {
+func TestVersionDefaultsToHumanText(t *testing.T) {
 	testRootCommand(t)
 
 	oldVersion, oldCommit, oldDate := buildinfo.Version, buildinfo.Commit, buildinfo.Date
@@ -83,12 +83,11 @@ func TestVersionDefaultsToTableOutput(t *testing.T) {
 	}
 
 	got := out.String()
-	// Default format is table — should show key-value pairs, not JSON braces.
 	if strings.Contains(got, "{") {
-		t.Fatalf("default output should be table, not JSON: %q", got)
+		t.Fatalf("default output should be human text, not JSON: %q", got)
 	}
-	if !strings.Contains(got, "0.2.0") {
-		t.Fatalf("table output missing version: %q", got)
+	if !strings.HasPrefix(got, "ikuai-cli 0.2.0\n") {
+		t.Fatalf("human output should start with version: %q", got)
 	}
 }
 

--- a/internal/cmd/version/command.go
+++ b/internal/cmd/version/command.go
@@ -1,8 +1,11 @@
 package version
 
 import (
+	"fmt"
+
 	"github.com/ikuaidev/ikuai-cli/internal/buildinfo"
 	"github.com/ikuaidev/ikuai-cli/internal/cliapp"
+	"github.com/ikuaidev/ikuai-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -10,14 +13,34 @@ func New(app *cliapp.Runtime) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Show version",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			app.PrintJSON(map[string]string{
+			info := map[string]string{
 				"name":    "ikuai-cli",
 				"version": buildinfo.Version,
 				"commit":  buildinfo.Commit,
 				"date":    buildinfo.Date,
-			})
+			}
+			if app.Format == output.Table && len(app.UserColumns) == 0 && !app.WideMode {
+				printHumanVersion(app)
+				return nil
+			}
+			if app.Format == output.Table {
+				app.PrintJSON([]map[string]string{info})
+				return nil
+			}
+			app.PrintJSON(info)
 			return nil
 		},
+	}
+}
+
+func printHumanVersion(app *cliapp.Runtime) {
+	_, _ = fmt.Fprintf(app.Stdout, "ikuai-cli %s\n", buildinfo.Version)
+	if buildinfo.Commit != "" && buildinfo.Commit != "none" {
+		_, _ = fmt.Fprintf(app.Stdout, "commit: %s\n", buildinfo.Commit)
+	}
+	if buildinfo.Date != "" && buildinfo.Date != "unknown" {
+		_, _ = fmt.Fprintf(app.Stdout, "built: %s\n", buildinfo.Date)
 	}
 }

--- a/internal/cmd/version/command_test.go
+++ b/internal/cmd/version/command_test.go
@@ -35,7 +35,7 @@ func TestVersionCommandWithFormatJSON(t *testing.T) {
 	}
 }
 
-func TestVersionCommandDefaultsToTable(t *testing.T) {
+func TestVersionCommandDefaultsToHumanText(t *testing.T) {
 	oldVersion, oldCommit, oldDate := buildinfo.Version, buildinfo.Commit, buildinfo.Date
 	buildinfo.Version = "2.0.0"
 	buildinfo.Commit = "fedcba9"
@@ -53,14 +53,28 @@ func TestVersionCommandDefaultsToTable(t *testing.T) {
 	}
 
 	got := out.String()
-	// Default is table — should not contain JSON braces.
 	if strings.Contains(got, "{") {
-		t.Fatalf("default output should be table, not JSON: %q", got)
+		t.Fatalf("default output should be human text, not JSON: %q", got)
 	}
-	if !strings.Contains(got, "2.0.0") {
-		t.Fatalf("table output missing version: %q", got)
+	if !strings.HasPrefix(got, "ikuai-cli 2.0.0\n") {
+		t.Fatalf("human output should start with version: %q", got)
 	}
-	if !strings.Contains(got, "fedcba9") {
-		t.Fatalf("table output missing commit: %q", got)
+	if !strings.Contains(got, "commit: fedcba9") {
+		t.Fatalf("human output missing commit: %q", got)
+	}
+	if !strings.Contains(got, "built: 2026-04-07T10:00:00Z") {
+		t.Fatalf("human output missing build date: %q", got)
+	}
+}
+
+func TestVersionCommandRejectsExtraArgs(t *testing.T) {
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"extra"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("Execute() error = nil, want error")
 	}
 }

--- a/skills/version.md
+++ b/skills/version.md
@@ -1,0 +1,22 @@
+---
+name: ikuai-version
+description: Show ikuai-cli build metadata such as version, commit, and build date.
+---
+
+# Version
+
+人工检查时默认先显示版本号：
+
+```bash
+ikuai-cli version
+```
+
+发布构建的版本号来自 git tag，例如 `v1.0.8`。
+
+Agent 或脚本需要解析当前 CLI 构建信息时，优先使用 JSON：
+
+```bash
+ikuai-cli version --format json
+ikuai-cli version --format yaml
+ikuai-cli version --columns name,version,commit,date
+```


### PR DESCRIPTION
## Summary

- Show `ikuai-cli version` as version-first human output while preserving structured formats for automation.
- Use Git tag values for release builds and tagged local builds, with `dev` as the untagged fallback.
- Add regression coverage for extra args and tag-style version output.