### PR TITLE
fix(auth): normalize router URL to https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ AGENTS.md
 .claude/
 document/
 /web-api-yaml/
+/ikuai-health-dashboard/
 
 # Build artifacts
 dist/

--- a/internal/cmd/auth/command.go
+++ b/internal/cmd/auth/command.go
@@ -1,10 +1,19 @@
 package auth
 
 import (
+	"strings"
+
 	"github.com/ikuaidev/ikuai-cli/internal/cliapp"
 	"github.com/ikuaidev/ikuai-cli/internal/session"
 	"github.com/spf13/cobra"
 )
+
+type setURLResult struct {
+	Message    string `json:"message"`
+	BaseURL    string `json:"base_url"`
+	Normalized bool   `json:"normalized"`
+	InputURL   string `json:"input_url,omitempty"`
+}
 
 func New(app *cliapp.Runtime) *cobra.Command {
 	authCmd := &cobra.Command{
@@ -26,20 +35,26 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			if len(args) > 0 && urlVal == "" {
 				urlVal = args[0]
 			}
-			if urlVal == "" {
+			if strings.TrimSpace(urlVal) == "" {
 				return &cliapp.ValidationError{Message: "URL is required: use --url or pass as argument"}
 			}
-			urlVal = session.NormalizeBaseURL(urlVal)
-			if urlVal == "" {
-				return &cliapp.ValidationError{Message: "URL is required: use --url or pass as argument"}
+			inputURL := urlVal
+			baseURL, normalized, err := session.NormalizeBaseURL(urlVal)
+			if err != nil {
+				return &cliapp.ValidationError{Message: invalidRouterURLMessage(err)}
 			}
-			if err := session.SaveBaseURL(urlVal); err != nil {
+			if err := session.SaveBaseURL(baseURL); err != nil {
 				return err
 			}
-			app.PrintJSON(map[string]string{
-				"message":  "Base URL saved",
-				"base_url": urlVal,
-			})
+			result := setURLResult{
+				Message:    "Base URL saved",
+				BaseURL:    baseURL,
+				Normalized: normalized,
+			}
+			if normalized {
+				result.InputURL = safeInputURLForOutput(inputURL)
+			}
+			app.PrintJSON(result)
 			return nil
 		},
 	}
@@ -96,4 +111,16 @@ func New(app *cliapp.Runtime) *cobra.Command {
 
 	authCmd.AddCommand(authSetURLCmd, authSetTokenCmd, authClearCmd, authStatusCmd)
 	return authCmd
+}
+
+func invalidRouterURLMessage(err error) string {
+	return "Invalid router URL.\n\n" + err.Error() + "\n\nTry:\n  ikuai-cli auth set-url 192.168.1.1\n  ikuai-cli auth set-url https://192.168.1.1"
+}
+
+func safeInputURLForOutput(input string) string {
+	input = strings.TrimSpace(input)
+	if strings.ContainsAny(input, "?#@") {
+		return ""
+	}
+	return input
 }

--- a/internal/cmd/auth/command.go
+++ b/internal/cmd/auth/command.go
@@ -29,6 +29,10 @@ func New(app *cliapp.Runtime) *cobra.Command {
 			if urlVal == "" {
 				return &cliapp.ValidationError{Message: "URL is required: use --url or pass as argument"}
 			}
+			urlVal = session.NormalizeBaseURL(urlVal)
+			if urlVal == "" {
+				return &cliapp.ValidationError{Message: "URL is required: use --url or pass as argument"}
+			}
 			if err := session.SaveBaseURL(urlVal); err != nil {
 				return err
 			}

--- a/internal/cmd/auth/command_test.go
+++ b/internal/cmd/auth/command_test.go
@@ -30,6 +30,73 @@ func TestSetURLTrimsTrailingSlash(t *testing.T) {
 	}
 }
 
+func TestSetURLNormalizesToHTTPS(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "http scheme",
+			args: []string{"set-url", "http://192.168.1.1/"},
+			want: "https://192.168.1.1",
+		},
+		{
+			name: "missing scheme",
+			args: []string{"set-url", "192.168.1.1"},
+			want: "https://192.168.1.1",
+		},
+		{
+			name: "flag value",
+			args: []string{"set-url", "--url", "router.local/"},
+			want: "https://router.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("IKUAI_CLI_CONFIG_FILE", t.TempDir()+"/config.json")
+
+			var out bytes.Buffer
+			app := cliapp.New(&out, &out)
+			app.Format = output.JSON
+
+			cmd := New(app)
+			cmd.SetArgs(tt.args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			s, err := session.Load()
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if s.BaseURL != tt.want {
+				t.Fatalf("BaseURL = %q, want %q", s.BaseURL, tt.want)
+			}
+
+			got := strings.TrimSpace(out.String())
+			wantOutput := `{"base_url":"` + tt.want + `","message":"Base URL saved"}`
+			if got != wantOutput {
+				t.Fatalf("output = %q, want %q", got, wantOutput)
+			}
+		})
+	}
+}
+
+func TestSetURLRequiresNonBlankURL(t *testing.T) {
+	t.Setenv("IKUAI_CLI_CONFIG_FILE", t.TempDir()+"/config.json")
+
+	var out bytes.Buffer
+	cmd := New(cliapp.New(&out, &out))
+	cmd.SetArgs([]string{"set-url", "   "})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when URL is blank, got nil")
+	}
+}
+
 func TestSetTokenSavesToken(t *testing.T) {
 	t.Setenv("IKUAI_CLI_CONFIG_FILE", t.TempDir()+"/config.json")
 

--- a/internal/cmd/auth/command_test.go
+++ b/internal/cmd/auth/command_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -32,24 +33,44 @@ func TestSetURLTrimsTrailingSlash(t *testing.T) {
 
 func TestSetURLNormalizesToHTTPS(t *testing.T) {
 	tests := []struct {
-		name string
-		args []string
-		want string
+		name       string
+		args       []string
+		want       string
+		normalized bool
+		wantInput  string
 	}{
 		{
-			name: "http scheme",
-			args: []string{"set-url", "http://192.168.1.1/"},
-			want: "https://192.168.1.1",
+			name:       "http scheme",
+			args:       []string{"set-url", "http://192.168.1.1/"},
+			want:       "https://192.168.1.1",
+			normalized: true,
+			wantInput:  "http://192.168.1.1/",
 		},
 		{
-			name: "missing scheme",
-			args: []string{"set-url", "192.168.1.1"},
-			want: "https://192.168.1.1",
+			name:       "missing scheme",
+			args:       []string{"set-url", "192.168.1.1"},
+			want:       "https://192.168.1.1",
+			normalized: true,
+			wantInput:  "192.168.1.1",
 		},
 		{
-			name: "flag value",
-			args: []string{"set-url", "--url", "router.local/"},
-			want: "https://router.local",
+			name:       "flag value",
+			args:       []string{"set-url", "--url", "router.local/"},
+			want:       "https://router.local",
+			normalized: true,
+			wantInput:  "router.local/",
+		},
+		{
+			name:       "path query and fragment",
+			args:       []string{"set-url", "https://192.168.1.1/login?from=cli#top"},
+			want:       "https://192.168.1.1",
+			normalized: true,
+		},
+		{
+			name:       "already normalized",
+			args:       []string{"set-url", "https://router.local"},
+			want:       "https://router.local",
+			normalized: false,
 		},
 	}
 
@@ -75,10 +96,89 @@ func TestSetURLNormalizesToHTTPS(t *testing.T) {
 				t.Fatalf("BaseURL = %q, want %q", s.BaseURL, tt.want)
 			}
 
-			got := strings.TrimSpace(out.String())
-			wantOutput := `{"base_url":"` + tt.want + `","message":"Base URL saved"}`
-			if got != wantOutput {
-				t.Fatalf("output = %q, want %q", got, wantOutput)
+			var got struct {
+				Message    string `json:"message"`
+				BaseURL    string `json:"base_url"`
+				Normalized bool   `json:"normalized"`
+				InputURL   string `json:"input_url,omitempty"`
+			}
+			if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &got); err != nil {
+				t.Fatalf("output JSON error = %v; output = %q", err, out.String())
+			}
+			if got.Message != "Base URL saved" {
+				t.Fatalf("message = %q, want %q", got.Message, "Base URL saved")
+			}
+			if got.BaseURL != tt.want {
+				t.Fatalf("output base_url = %q, want %q", got.BaseURL, tt.want)
+			}
+			if got.Normalized != tt.normalized {
+				t.Fatalf("normalized = %v, want %v", got.Normalized, tt.normalized)
+			}
+			if got.InputURL != tt.wantInput {
+				t.Fatalf("input_url = %q, want %q", got.InputURL, tt.wantInput)
+			}
+			if tt.normalized && strings.ContainsAny(got.InputURL, "?#@") {
+				t.Fatalf("input_url = %q, want sensitive URL parts omitted", got.InputURL)
+			}
+			if !tt.normalized && got.InputURL != "" {
+				t.Fatalf("input_url = %q, want empty for unchanged input", got.InputURL)
+			}
+		})
+	}
+}
+
+func TestSetURLRejectsInvalidRouterURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name:    "unsupported scheme",
+			input:   "ftp://192.168.1.1",
+			wantErr: "only accepts http or https",
+		},
+		{
+			name:    "userinfo",
+			input:   "https://admin:secret@192.168.1.1",
+			wantErr: "must not include username or password",
+		},
+		{
+			name:    "spaces",
+			input:   "not a url with spaces",
+			wantErr: "invalid router host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("IKUAI_CLI_CONFIG_FILE", t.TempDir()+"/config.json")
+
+			var out bytes.Buffer
+			cmd := New(cliapp.New(&out, &out))
+			cmd.SetArgs([]string{"set-url", tt.input})
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("Execute() error = nil, want error")
+			}
+			for _, want := range []string{
+				"Invalid router URL",
+				tt.wantErr,
+				"ikuai-cli auth set-url 192.168.1.1",
+				"ikuai-cli auth set-url https://192.168.1.1",
+			} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %q, want to contain %q", err.Error(), want)
+				}
+			}
+
+			s, loadErr := session.Load()
+			if loadErr != nil {
+				t.Fatalf("Load() error = %v", loadErr)
+			}
+			if s.BaseURL != "" {
+				t.Fatalf("BaseURL = %q, want empty after invalid URL", s.BaseURL)
 			}
 		})
 	}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -55,13 +55,30 @@ func save(s *Session) error {
 	return os.WriteFile(path, data, 0600)
 }
 
-// SaveBaseURL stores the base URL (trailing slash stripped).
+// NormalizeBaseURL stores router API URLs as HTTPS without a trailing slash.
+func NormalizeBaseURL(url string) string {
+	baseURL := strings.TrimRight(strings.TrimSpace(url), "/")
+	if baseURL == "" {
+		return ""
+	}
+	lowerURL := strings.ToLower(baseURL)
+	switch {
+	case strings.HasPrefix(lowerURL, "http://"):
+		return "https://" + baseURL[len("http://"):]
+	case strings.HasPrefix(lowerURL, "https://"):
+		return "https://" + baseURL[len("https://"):]
+	default:
+		return "https://" + baseURL
+	}
+}
+
+// SaveBaseURL stores the base URL as HTTPS (trailing slash stripped).
 func SaveBaseURL(url string) error {
 	s, _ := Load()
 	if s == nil {
 		s = &Session{}
 	}
-	s.BaseURL = strings.TrimRight(url, "/")
+	s.BaseURL = NormalizeBaseURL(url)
 	return save(s)
 }
 
@@ -81,7 +98,7 @@ func SaveLogin(url, token string) error {
 	if s == nil {
 		s = &Session{}
 	}
-	s.BaseURL = strings.TrimRight(url, "/")
+	s.BaseURL = NormalizeBaseURL(url)
 	s.Token = token
 	return save(s)
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -3,6 +3,8 @@ package session
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,21 +57,45 @@ func save(s *Session) error {
 	return os.WriteFile(path, data, 0600)
 }
 
-// NormalizeBaseURL stores router API URLs as HTTPS without a trailing slash.
-func NormalizeBaseURL(url string) string {
-	baseURL := strings.TrimRight(strings.TrimSpace(url), "/")
-	if baseURL == "" {
-		return ""
+// NormalizeBaseURL stores router API URLs as HTTPS without a path, query, fragment, or trailing slash.
+func NormalizeBaseURL(rawURL string) (string, bool, error) {
+	input := strings.TrimSpace(rawURL)
+	if input == "" {
+		return "", false, fmt.Errorf("missing router host")
 	}
+	if strings.ContainsAny(input, " \t\r\n") {
+		return "", false, fmt.Errorf("invalid router host")
+	}
+
+	baseURL := input
 	lowerURL := strings.ToLower(baseURL)
 	switch {
 	case strings.HasPrefix(lowerURL, "http://"):
-		return "https://" + baseURL[len("http://"):]
+		baseURL = "https://" + baseURL[len("http://"):]
 	case strings.HasPrefix(lowerURL, "https://"):
-		return "https://" + baseURL[len("https://"):]
+		baseURL = "https://" + baseURL[len("https://"):]
+	case strings.Contains(lowerURL, "://"):
+		return "", false, fmt.Errorf("only accepts http or https router URLs")
 	default:
-		return "https://" + baseURL
+		baseURL = "https://" + baseURL
 	}
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", false, fmt.Errorf("invalid router host")
+	}
+	if parsed.User != nil {
+		return "", false, fmt.Errorf("router URL must not include username or password")
+	}
+	if parsed.Host == "" || parsed.Hostname() == "" {
+		return "", false, fmt.Errorf("missing router host")
+	}
+	if strings.ContainsAny(parsed.Host, " \t\r\n") {
+		return "", false, fmt.Errorf("invalid router host")
+	}
+
+	normalized := "https://" + parsed.Host
+	return normalized, normalized != input, nil
 }
 
 // SaveBaseURL stores the base URL as HTTPS (trailing slash stripped).
@@ -78,7 +104,11 @@ func SaveBaseURL(url string) error {
 	if s == nil {
 		s = &Session{}
 	}
-	s.BaseURL = NormalizeBaseURL(url)
+	baseURL, _, err := NormalizeBaseURL(url)
+	if err != nil {
+		return err
+	}
+	s.BaseURL = baseURL
 	return save(s)
 }
 
@@ -98,7 +128,11 @@ func SaveLogin(url, token string) error {
 	if s == nil {
 		s = &Session{}
 	}
-	s.BaseURL = NormalizeBaseURL(url)
+	baseURL, _, err := NormalizeBaseURL(url)
+	if err != nil {
+		return err
+	}
+	s.BaseURL = baseURL
 	s.Token = token
 	return save(s)
 }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -23,6 +24,102 @@ func TestSaveBaseURLUsesOverridePathAndTrimsSlash(t *testing.T) {
 
 	if _, err := os.Stat(os.Getenv(configFileEnv)); err != nil {
 		t.Fatalf("session file not written to override path: %v", err)
+	}
+}
+
+func TestNormalizeBaseURLCorrectsCommonInputs(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		want        string
+		wantChanged bool
+	}{
+		{
+			name:        "bare host",
+			input:       "192.168.1.1",
+			want:        "https://192.168.1.1",
+			wantChanged: true,
+		},
+		{
+			name:        "http scheme",
+			input:       "http://192.168.1.1/",
+			want:        "https://192.168.1.1",
+			wantChanged: true,
+		},
+		{
+			name:        "path query and fragment",
+			input:       "https://192.168.1.1/login?from=cli#top",
+			want:        "https://192.168.1.1",
+			wantChanged: true,
+		},
+		{
+			name:        "host with port",
+			input:       "192.168.1.1:8443",
+			want:        "https://192.168.1.1:8443",
+			wantChanged: true,
+		},
+		{
+			name:        "already normalized",
+			input:       "https://router.local",
+			want:        "https://router.local",
+			wantChanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed, err := NormalizeBaseURL(tt.input)
+			if err != nil {
+				t.Fatalf("NormalizeBaseURL() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeBaseURL() = %q, want %q", got, tt.want)
+			}
+			if changed != tt.wantChanged {
+				t.Fatalf("changed = %v, want %v", changed, tt.wantChanged)
+			}
+		})
+	}
+}
+
+func TestNormalizeBaseURLRejectsUnclearInputs(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name:    "unsupported scheme",
+			input:   "ftp://192.168.1.1",
+			wantErr: "only accepts http or https",
+		},
+		{
+			name:    "missing host",
+			input:   "https://",
+			wantErr: "missing router host",
+		},
+		{
+			name:    "userinfo",
+			input:   "https://admin:secret@192.168.1.1",
+			wantErr: "must not include username or password",
+		},
+		{
+			name:    "spaces",
+			input:   "not a url with spaces",
+			wantErr: "invalid router host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := NormalizeBaseURL(tt.input)
+			if err == nil {
+				t.Fatal("NormalizeBaseURL() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want to contain %q", err.Error(), tt.wantErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Normalize `auth set-url` input so `http://...` and bare router addresses are saved and shown as `https://...`
- Reject unclear router URLs with actionable examples instead of saving confusing values
- Avoid echoing unsafe pasted URL details while still reporting when input was corrected
- Ignore the local `ikuai-health-dashboard/` workspace directory
