### PR TITLE
fix(errors): avoid duplicate command errors

### DIFF
--- a/internal/cmd/repl.go
+++ b/internal/cmd/repl.go
@@ -198,21 +198,25 @@ func runREPL(_ *cobra.Command, _ []string) error {
 			continue
 		}
 
-		// Reset ALL flags before each REPL command to prevent stale values
-		// from leaking across iterations. MergeDataWithFlags checks f.Changed,
-		// so stale Changed=true bits would silently inject previous values.
-		resetAllFlags(rootCmd)
-
-		// Execute via rootCmd
-		rootCmd.SetArgs(args)
-		if err := rootCmd.Execute(); err != nil {
+		if err := executeREPLCommand(args); err != nil {
 			fmt.Fprintln(os.Stderr, "✗", err)
 		}
-		rootCmd.SetArgs(nil)
 	}
 
 	fmt.Println("Goodbye!")
 	return nil
+}
+
+func executeREPLCommand(args []string) error {
+	// Reset ALL flags before each REPL command to prevent stale values
+	// from leaking across iterations. MergeDataWithFlags checks f.Changed,
+	// so stale Changed=true bits would silently inject previous values.
+	resetAllFlags(rootCmd)
+
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	rootCmd.SetArgs(nil)
+	return err
 }
 
 // splitForCompletion splits the text before the cursor into fully-typed

--- a/internal/cmd/repl_test.go
+++ b/internal/cmd/repl_test.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
+	"io"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -51,6 +54,27 @@ func TestSplitArgs(t *testing.T) {
 				t.Fatalf("splitArgs(%q) = %#v, want %#v", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestREPLCommandErrorIsPrintedOnce(t *testing.T) {
+	testRootCommand(t)
+	var errOut bytes.Buffer
+	flushStderr := saveREPLStderr(t, &errOut)
+
+	err := executeREPLCommand([]string{"auth", "set-token"})
+	if err == nil {
+		t.Fatal("expected auth set-token to fail")
+	}
+	fmt.Fprintln(os.Stderr, "✗", err)
+	flushStderr()
+
+	got := errOut.String()
+	if strings.Contains(got, "Error:") {
+		t.Fatalf("stderr = %q, did not want cobra automatic error output", got)
+	}
+	if strings.Count(got, "✗ TOKEN is required") != 1 {
+		t.Fatalf("stderr = %q, want exactly one REPL error", got)
 	}
 }
 
@@ -134,6 +158,42 @@ func saveBannerState(t *testing.T, buf *bytes.Buffer) {
 	origStdout, origColor := stdout, useColor
 	stdout = buf
 	t.Cleanup(func() { stdout, useColor = origStdout, origColor })
+}
+
+func saveREPLStderr(t *testing.T, buf *bytes.Buffer) func() {
+	t.Helper()
+
+	oldStderr := os.Stderr
+	readFile, writeFile, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stderr = writeFile
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+	})
+
+	done := make(chan string, 1)
+	go func() {
+		var captured bytes.Buffer
+		_, _ = io.Copy(&captured, readFile)
+		done <- captured.String()
+	}()
+
+	flushed := false
+	flush := func() {
+		if flushed {
+			return
+		}
+		flushed = true
+		_ = writeFile.Close()
+		buf.WriteString(<-done)
+		_ = readFile.Close()
+		os.Stderr = oldStderr
+	}
+
+	t.Cleanup(flush)
+	return flush
 }
 
 func TestBannerUnauthed(t *testing.T) {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -45,10 +44,11 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:          "ikuai-cli",
-	Short:        "iKuai router local API v4.0 CLI",
-	Long:         `CLI for managing an iKuai router via its local REST API (v4.0). Default output is table; use --format json/yaml for machine-friendly output.`,
-	SilenceUsage: true,
+	Use:           "ikuai-cli",
+	Short:         "iKuai router local API v4.0 CLI",
+	Long:          `CLI for managing an iKuai router via its local REST API (v4.0). Default output is table; use --format json/yaml for machine-friendly output.`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	// RunE is set in init() to avoid initialization cycle with repl.go
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		app.Stdout = stdout
@@ -125,19 +125,40 @@ const (
 // Execute runs the root command.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		code := classifyError(err)
-		// Non-TTY: emit JSON error envelope to stderr for machine consumers.
-		if os.Getenv("IKUAI_FORCE_TTY") != "1" && !isTerminalWriter(stderr) {
-			envelope := map[string]interface{}{
-				"ok":    false,
-				"error": buildErrorPayload(err, code),
-			}
-			enc := json.NewEncoder(stderr)
-			enc.SetEscapeHTML(false)
-			_ = enc.Encode(envelope)
+		stderrIsTTY := os.Getenv("IKUAI_FORCE_TTY") == "1" || isTerminalWriter(stderr)
+		formatExplicit := rootCmd.PersistentFlags().Changed("format")
+		errorFormat, formatErr := output.FormatFromString(formatStr)
+		if formatErr != nil {
+			errorFormat = output.Table
 		}
-		os.Exit(code)
+		os.Exit(handleExecuteError(err, stderrIsTTY, formatExplicit, errorFormat, stderr))
 	}
+}
+
+func handleExecuteError(err error, stderrIsTTY bool, formatExplicit bool, format output.Format, errWriter io.Writer) int {
+	code := classifyError(err)
+	errorFormat := errorOutputFormat(stderrIsTTY, formatExplicit, format)
+	if errorFormat == output.Table {
+		_, _ = fmt.Fprintln(errWriter, "Error:", err)
+		return code
+	}
+
+	envelope := map[string]interface{}{
+		"ok":    false,
+		"error": buildErrorPayload(err, code),
+	}
+	output.New(errWriter, errWriter, errorFormat).PrintValue(envelope)
+	return code
+}
+
+func errorOutputFormat(stderrIsTTY bool, formatExplicit bool, format output.Format) output.Format {
+	if formatExplicit {
+		return format
+	}
+	if stderrIsTTY {
+		return output.Table
+	}
+	return output.JSON
 }
 
 // classifyError maps an error to an exit code.

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -2,11 +2,15 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/ikuaidev/ikuai-cli/internal/buildinfo"
+	"github.com/ikuaidev/ikuai-cli/internal/cliapp"
+	"github.com/ikuaidev/ikuai-cli/internal/output"
 	"github.com/ikuaidev/ikuai-cli/internal/session"
+	"gopkg.in/yaml.v3"
 )
 
 func TestAuthStatusWithFormatJSON(t *testing.T) {
@@ -224,6 +228,148 @@ func TestColumnsFlag(t *testing.T) {
 	got := out.String()
 	if !strings.Contains(got, "NAME") || !strings.Contains(got, "VERSION") {
 		t.Fatalf("--columns should show requested columns: %q", got)
+	}
+}
+
+func TestHandleExecuteErrorTTYPrintsSingleHumanError(t *testing.T) {
+	var errOut bytes.Buffer
+	err := &cliapp.ValidationError{Message: "bad input"}
+
+	code := handleExecuteError(err, true, false, output.Table, &errOut)
+
+	if code != ExitValidation {
+		t.Fatalf("exit code = %d, want %d", code, ExitValidation)
+	}
+	got := errOut.String()
+	if strings.Count(got, "Error: bad input") != 1 {
+		t.Fatalf("stderr = %q, want exactly one human error", got)
+	}
+	if strings.Contains(got, `"ok":false`) {
+		t.Fatalf("stderr = %q, did not want JSON envelope for TTY", got)
+	}
+}
+
+func TestHandleExecuteErrorNonTTYPrintsOnlyJSONEnvelope(t *testing.T) {
+	var errOut bytes.Buffer
+	err := &cliapp.ValidationError{Message: "bad input"}
+
+	code := handleExecuteError(err, false, false, output.Table, &errOut)
+
+	if code != ExitValidation {
+		t.Fatalf("exit code = %d, want %d", code, ExitValidation)
+	}
+	got := errOut.String()
+	if strings.Contains(got, "Error:") {
+		t.Fatalf("stderr = %q, did not want cobra-style Error prefix", got)
+	}
+	var envelope struct {
+		OK    bool `json:"ok"`
+		Error struct {
+			Message  string `json:"message"`
+			ExitCode int    `json:"exit_code"`
+			Type     string `json:"type"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(errOut.Bytes()), &envelope); err != nil {
+		t.Fatalf("stderr JSON error = %v; stderr = %q", err, got)
+	}
+	if envelope.OK {
+		t.Fatalf("ok = true, want false")
+	}
+	if envelope.Error.Message != "bad input" {
+		t.Fatalf("message = %q, want %q", envelope.Error.Message, "bad input")
+	}
+	if envelope.Error.ExitCode != ExitValidation {
+		t.Fatalf("exit_code = %d, want %d", envelope.Error.ExitCode, ExitValidation)
+	}
+	if envelope.Error.Type != "validation_error" {
+		t.Fatalf("type = %q, want validation_error", envelope.Error.Type)
+	}
+}
+
+func TestHandleExecuteErrorNonTTYExplicitYAMLPrintsYAMLEnvelope(t *testing.T) {
+	var errOut bytes.Buffer
+	err := &cliapp.ValidationError{Message: "bad input"}
+
+	code := handleExecuteError(err, false, true, output.YAML, &errOut)
+
+	if code != ExitValidation {
+		t.Fatalf("exit code = %d, want %d", code, ExitValidation)
+	}
+	got := errOut.String()
+	if strings.Contains(got, "Error:") {
+		t.Fatalf("stderr = %q, did not want human error for explicit YAML", got)
+	}
+	if strings.Contains(got, `{"error"`) {
+		t.Fatalf("stderr = %q, did not want JSON for explicit YAML", got)
+	}
+	var envelope struct {
+		OK    bool `yaml:"ok"`
+		Error struct {
+			Message  string `yaml:"message"`
+			ExitCode int    `yaml:"exit_code"`
+			Type     string `yaml:"type"`
+		} `yaml:"error"`
+	}
+	if err := yaml.Unmarshal(errOut.Bytes(), &envelope); err != nil {
+		t.Fatalf("stderr YAML error = %v; stderr = %q", err, got)
+	}
+	if envelope.OK {
+		t.Fatalf("ok = true, want false")
+	}
+	if envelope.Error.Message != "bad input" {
+		t.Fatalf("message = %q, want %q", envelope.Error.Message, "bad input")
+	}
+	if envelope.Error.ExitCode != ExitValidation {
+		t.Fatalf("exit_code = %d, want %d", envelope.Error.ExitCode, ExitValidation)
+	}
+	if envelope.Error.Type != "validation_error" {
+		t.Fatalf("type = %q, want validation_error", envelope.Error.Type)
+	}
+}
+
+func TestHandleExecuteErrorExplicitJSONPrintsJSONEnvelopeInTTY(t *testing.T) {
+	var errOut bytes.Buffer
+	err := &cliapp.ValidationError{Message: "bad input"}
+
+	code := handleExecuteError(err, true, true, output.JSON, &errOut)
+
+	if code != ExitValidation {
+		t.Fatalf("exit code = %d, want %d", code, ExitValidation)
+	}
+	got := errOut.String()
+	if strings.Contains(got, "Error:") {
+		t.Fatalf("stderr = %q, did not want human error for explicit JSON", got)
+	}
+	var envelope struct {
+		OK    bool `json:"ok"`
+		Error struct {
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(errOut.Bytes()), &envelope); err != nil {
+		t.Fatalf("stderr JSON error = %v; stderr = %q", err, got)
+	}
+	if envelope.Error.Type != "validation_error" {
+		t.Fatalf("type = %q, want validation_error", envelope.Error.Type)
+	}
+}
+
+func TestRootCommandSilencesCobraErrorPrinting(t *testing.T) {
+	testRootCommand(t)
+
+	var out bytes.Buffer
+	setRootOutput(t, &out)
+
+	rootCmd.SetArgs([]string{"auth", "set-token"})
+	_, err := rootCmd.ExecuteC()
+	if err == nil {
+		t.Fatal("expected auth set-token to fail")
+	}
+
+	got := out.String()
+	if strings.Contains(got, "Error:") {
+		t.Fatalf("stderr = %q, did not want cobra automatic error output", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Print command errors once across normal CLI and REPL usage
- Respect explicit JSON/YAML output formats for structured error output
- Keep default non-TTY errors machine-readable while preserving human-readable TTY errors