### PR TITLE
fix(output): align table columns by display width

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ikuaidev/ikuai-cli
 go 1.25.0
 
 require (
+	github.com/mattn/go-runewidth v0.0.3
 	github.com/peterh/liner v1.2.2
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
@@ -13,6 +14,5 @@ require (
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/mattn/go-runewidth v0.0.3 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 )

--- a/internal/cmd/log/behavior_test.go
+++ b/internal/cmd/log/behavior_test.go
@@ -269,6 +269,40 @@ func TestURLVisitsLogDefaultTableUsesYamlFields(t *testing.T) {
 	}
 }
 
+func TestURLVisitsLogDefaultTablePrioritizesVisitedURLAndAppNameInNarrowTTY(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	app := cliapp.New(&out, &out)
+	app.Format = output.Table
+	app.TermWidth = 70
+	app.Session = &session.Session{BaseURL: "https://router.local", Token: "token-log"}
+	app.APIClient = api.NewWithHTTPClient(app.Session.BaseURL, app.Session.Token, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/api/v4.0/log/url-visits" {
+				t.Fatalf("path = %q, want %q", req.URL.Path, "/api/v4.0/log/url-visits")
+			}
+			return jsonResponse(`{"code":0,"message":"Success","results":{"data":[{"id":2001,"timestamp":1761842271,"ip_addr":"192.168.1.100","mac":"08:9b:4b:00:10:6e","host":"www.example.com","uri":"/news/detail?id=1","comment":"office","appname":"browser","icon":"browser","client_model":"ThinkPad","client_type":"PC"}]}}`), nil
+		}),
+	})
+
+	cmd := New(app)
+	cmd.SetArgs([]string{"url-visits", "list", "--page", "1", "--page-size", "5"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{"HOST", "URI", "APPNAME", "CLIENT_TYPE", "www.example.com", "/news/detail?id=1", "browser", "PC"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("narrow table output = %q, want field/value %s", got, want)
+		}
+	}
+	if !strings.Contains(got, "columns hidden") {
+		t.Fatalf("narrow table output = %q, want auto-fit hidden columns hint", got)
+	}
+}
+
 func TestURLVisitsLogClearRequestsDelete(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/log/command.go
+++ b/internal/cmd/log/command.go
@@ -23,7 +23,7 @@ var logResources = []logResource{
 	{name: "ddns", apiPath: "log/ddns", defaultColumns: []string{"id", "timestamp", "domain", "result", "ip_addr", "event"}},
 	{name: "notice", apiPath: "log/notice", defaultColumns: []string{"id", "timestamp", "type", "event", "ip_addr"}},
 	{name: "wireless", apiPath: "log/wireless", defaultColumns: []string{"id", "timestamp", "action", "mac", "apmac", "ssid", "errmsg", "signal"}},
-	{name: "url-visits", apiPath: "log/url-visits", defaultColumns: []string{"id", "timestamp", "ip_addr", "mac", "host", "uri", "appname", "client_type", "client_model", "comment"}},
+	{name: "url-visits", apiPath: "log/url-visits", defaultColumns: []string{"id", "host", "uri", "appname", "client_type", "timestamp", "ip_addr", "mac", "client_model", "comment"}},
 }
 
 func New(app *cliapp.Runtime) *cobra.Command {

--- a/internal/output/printer_test.go
+++ b/internal/output/printer_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/mattn/go-runewidth"
 )
 
 // --- Format parsing ---
@@ -906,4 +908,32 @@ func TestSingleLineCellNoExtraBlanks(t *testing.T) {
 			t.Fatalf("unexpected blank line at position %d in single-line table: %q", i, got)
 		}
 	}
+}
+
+func TestTableAlignsColumnsWithWideCharacters(t *testing.T) {
+	var out bytes.Buffer
+	p := New(&out, &out, Table)
+	p.Columns = []string{"id", "appname", "client_type"}
+	p.Print(json.RawMessage(`[{"id":1,"appname":"谷歌通用协议","client_type":"Windows10"},{"id":2,"appname":"HTTPS","client_type":"Windows10"}]`))
+
+	got := out.String()
+	lines := strings.Split(strings.TrimSpace(got), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("table lines = %d, want 3: %q", len(lines), got)
+	}
+
+	want := displayColumnStart(lines[0], "CLIENT_TYPE")
+	for _, line := range lines[1:] {
+		if gotStart := displayColumnStart(line, "Windows10"); gotStart != want {
+			t.Fatalf("CLIENT_TYPE column is not aligned:\n%s\nline %q starts at %d, want %d", got, line, gotStart, want)
+		}
+	}
+}
+
+func displayColumnStart(line, marker string) int {
+	idx := strings.Index(line, marker)
+	if idx < 0 {
+		return -1
+	}
+	return runewidth.StringWidth(line[:idx])
 }

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -9,6 +9,8 @@ import (
 	"text/tabwriter"
 	"time"
 	"unicode"
+
+	"github.com/mattn/go-runewidth"
 )
 
 // renderTable auto-detects the shape of v and prints a human-readable table.
@@ -66,20 +68,19 @@ func renderArrayTable(w io.Writer, items []interface{}, humanTime bool, columns 
 		keys, hidden = autoFitColumns(keys, items, humanTime, termWidth)
 	}
 
-	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-
 	// Header row.
 	headers := make([]string, len(keys))
 	for i, k := range keys {
 		headers[i] = toUpperSnakeCase(k)
 	}
-	_, _ = fmt.Fprintln(tw, strings.Join(headers, "\t"))
+	widths := tableColumnWidths(headers, items, keys, humanTime)
+	writeTableLine(w, headers, widths)
 
 	// Data rows — handle multi-line cells by splitting into sub-rows.
 	for _, item := range items {
 		obj, ok := item.(map[string]interface{})
 		if !ok {
-			_, _ = fmt.Fprintln(tw, formatCell(item))
+			_, _ = fmt.Fprintln(w, formatCell(item))
 			continue
 		}
 		cells := make([]string, len(keys))
@@ -95,7 +96,7 @@ func renderArrayTable(w io.Writer, items []interface{}, humanTime bool, columns 
 			}
 		}
 		if maxLines == 1 {
-			_, _ = fmt.Fprintln(tw, strings.Join(cells, "\t"))
+			writeTableLine(w, cells, widths)
 		} else {
 			// Split multi-line cells into sub-rows.
 			splitCells := make([][]string, len(cells))
@@ -109,17 +110,58 @@ func renderArrayTable(w io.Writer, items []interface{}, humanTime bool, columns 
 						parts[i] = splitCells[i][row]
 					}
 				}
-				_, _ = fmt.Fprintln(tw, strings.Join(parts, "\t"))
+				writeTableLine(w, parts, widths)
 			}
 			// Blank separator line after multi-line logical row.
-			_, _ = fmt.Fprintln(tw)
+			_, _ = fmt.Fprintln(w)
 		}
 	}
-	_ = tw.Flush()
 
 	if hidden > 0 {
 		_, _ = fmt.Fprintf(w, "(%d columns hidden, use --wide to see all)\n", hidden)
 	}
+}
+
+func tableColumnWidths(headers []string, items []interface{}, keys []string, humanTime bool) []int {
+	widths := make([]int, len(keys))
+	for i, header := range headers {
+		widths[i] = displayWidth(header)
+	}
+	for _, item := range items {
+		obj, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for i, k := range keys {
+			var cell string
+			if humanTime && k == "timestamp" {
+				cell = formatTimestamp(obj[k])
+			} else {
+				cell = formatCell(obj[k])
+			}
+			for _, line := range strings.Split(cell, "\n") {
+				if width := displayWidth(line); width > widths[i] {
+					widths[i] = width
+				}
+			}
+		}
+	}
+	return widths
+}
+
+func writeTableLine(w io.Writer, cells []string, widths []int) {
+	for i, cell := range cells {
+		if i > 0 {
+			_, _ = io.WriteString(w, "  ")
+		}
+		_, _ = io.WriteString(w, cell)
+		if i < len(cells)-1 {
+			if padding := widths[i] - displayWidth(cell); padding > 0 {
+				_, _ = io.WriteString(w, strings.Repeat(" ", padding))
+			}
+		}
+	}
+	_, _ = io.WriteString(w, "\n")
 }
 
 // renderObjectTable prints a single object as a vertical KEY | VALUE table.
@@ -516,7 +558,7 @@ func autoFitColumns(keys []string, items []interface{}, humanTime bool, termWidt
 	// Calculate max width per column (header vs cell values).
 	widths := make([]int, len(keys))
 	for i, k := range keys {
-		widths[i] = len(toUpperSnakeCase(k))
+		widths[i] = displayWidth(toUpperSnakeCase(k))
 	}
 	for _, item := range items {
 		obj, ok := item.(map[string]interface{})
@@ -532,8 +574,8 @@ func autoFitColumns(keys []string, items []interface{}, humanTime bool, termWidt
 			}
 			// For multi-line cells, use the longest line's width (not total string length).
 			for _, line := range strings.Split(cell, "\n") {
-				if len(line) > widths[i] {
-					widths[i] = len(line)
+				if width := displayWidth(line); width > widths[i] {
+					widths[i] = width
 				}
 			}
 		}
@@ -560,6 +602,10 @@ func autoFitColumns(keys []string, items []interface{}, humanTime bool, termWidt
 		return keys, 0
 	}
 	return keys[:fit], len(keys) - fit
+}
+
+func displayWidth(s string) int {
+	return runewidth.StringWidth(s)
 }
 
 // toUpperSnakeCase converts a JSON key to UPPER_SNAKE_CASE.


### PR DESCRIPTION
## Summary

- Table output now aligns columns by display width, keeping later columns lined up when values include wide characters such as Chinese text.
- URL visit lists now prioritize host, URI, app name, and client type in narrow terminal output so browsing details stay visible.
