### PR TITLE
feat(release): add Linux ARMv7 release artifact

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,9 +18,16 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - "7"
     ignore:
       - goos: windows
         goarch: arm64
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
     env:
       - CGO_ENABLED=0
 
@@ -30,7 +37,7 @@ archives:
       - ikuai-cli
     formats:
       - tar.gz
-    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     format_overrides:
       - goos: windows
         formats:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ go install github.com/ikuaidev/ikuai-cli/cmd/ikuai-cli@latest
 
 ```bash
 VERSION=0.1.0 ARCH=linux_amd64
+# ARM32 Linux uses ARCH=linux_armv7
 curl -fsSL "https://github.com/ikuaidev/ikuai-cli/releases/download/v${VERSION}/ikuai-cli_${ARCH}.tar.gz" -o ikuai-cli.tar.gz
 curl -fsSL "https://github.com/ikuaidev/ikuai-cli/releases/download/v${VERSION}/checksums.txt" -o checksums.txt
 sha256sum --check --ignore-missing checksums.txt
@@ -215,7 +216,7 @@ make smoke      # smoke test
 Cross-compile:
 
 ```bash
-make linux-amd64    make linux-arm64
+make linux-amd64    make linux-arm64    make linux-armv7
 make darwin-amd64   make darwin-arm64
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -31,6 +31,7 @@ go install github.com/ikuaidev/ikuai-cli/cmd/ikuai-cli@latest
 
 ```bash
 VERSION=0.1.0 ARCH=linux_amd64
+# ARM32 Linux 使用 ARCH=linux_armv7
 curl -fsSL "https://github.com/ikuaidev/ikuai-cli/releases/download/v${VERSION}/ikuai-cli_${ARCH}.tar.gz" -o ikuai-cli.tar.gz
 curl -fsSL "https://github.com/ikuaidev/ikuai-cli/releases/download/v${VERSION}/checksums.txt" -o checksums.txt
 sha256sum --check --ignore-missing checksums.txt
@@ -215,7 +216,7 @@ make smoke      # 冒烟测试
 交叉编译：
 
 ```bash
-make linux-amd64    make linux-arm64
+make linux-amd64    make linux-arm64    make linux-armv7
 make darwin-amd64   make darwin-arm64
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,8 @@ Download a prebuilt binary from the [Releases page](https://github.com/ikuaidev/
 ### Linux / macOS
 
 ```bash
-# Replace VERSION and ARCH as needed (amd64 or arm64)
+# Replace VERSION and ARCH as needed:
+# linux_amd64, linux_arm64, linux_armv7, darwin_amd64, or darwin_arm64
 VERSION=0.1.0
 ARCH=linux_amd64
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -66,5 +66,6 @@ Supported targets:
 
 - Linux `amd64`
 - Linux `arm64`
+- Linux `armv7`
 - Darwin `amd64`
 - Darwin `arm64`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,6 +38,7 @@ esac
 case "$ARCH" in
   x86_64|amd64)   ARCH="amd64" ;;
   aarch64|arm64)   ARCH="arm64" ;;
+  armv7l|armv7)    ARCH="armv7" ;;
   *)               echo "Error: unsupported architecture: $ARCH"; exit 1 ;;
 esac
 


### PR DESCRIPTION
## Summary

- Publish a Linux ARMv7 release archive for ARM32 devices.
- Teach the installer to select the ARMv7 archive on matching Linux systems.
- Document the new ARM32 release artifact in the install and release docs.